### PR TITLE
[WIP] npm scripts

### DIFF
--- a/.bin/index.js
+++ b/.bin/index.js
@@ -65,28 +65,25 @@ Vorpal
         }
       }
     }
-    var npmPromises = [];
-    npmPromises.push(
-      new Promise(function(p, f){
-        console.log("installing npm deps");
-        var child = Spawn("npm", ["install"], {
-          cwd: app, stdio: "inherit"
-        });
-        child.on("error", f);
-      })
-    );
+    // var npmPromises = [];
+    // npmPromises.push(
+    //   new Promise(function(p, f){
+    //     console.log("installing npm deps");
+    //     var child = Spawn("npm", ["install"], {
+    //       cwd: app, stdio: "inherit"
+    //     });
+    //     child.on("error", f);
+    //   })
+    // );
 
-    return Promise.all(npmPromises.concat(depPromises))
+    return Promise.all(depPromises)
       .then(function(){
-        console.log("Holtzmann should be ready to go!");
-        // console.log("you will need to clone it down manually");
-        // console.log("\n");
-        // console.log("    cd " + app + "/.remote/ && git clone https://github.com/NewSpring/ops-settings.git settings");
-        // console.log("\n");
+        Vorpal.hide();
         cb();
       })
       .catch(function(err) {
         console.error(err);
+        Vorpal.hide();
         cb();
       })
   });
@@ -154,7 +151,10 @@ Vorpal
 
     run();
 
-  });
+  })
+  // .cancel(function(){
+  //   Vorpal.hide();
+  // });
 
 
 Vorpal

--- a/package.json
+++ b/package.json
@@ -9,7 +9,15 @@
     "lint": "eslint",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "coverage": "jest --coverage"
+    "coverage": "jest --coverage",
+    "postinstall": "./.bin/index.js setup",
+    "setup": "./.bin/index.js setup",
+    "start": "./.bin/index.js run",
+    "web": "./.bin/index.js run",
+    "native": "./.bin/index.js run --native",
+    "ios": "./.bin/index.js run --ios",
+    "android": "./.bin/index.js run --android",
+    "device": "./.bin/index.js run --ios --device"
   },
   "repository": {
     "type": "git",
@@ -21,7 +29,8 @@
     "url": "https://github.com/NewSpring/my.newspring.cc/issues"
   },
   "bin": {
-    "apollos": "./.bin/index.js"
+    "holtzmann": "./.bin/index.js",
+    "hz": "./.bin/index.js"
   },
   "homepage": "https://github.com/NewSpring/my.newspring.cc",
   "jest": {


### PR DESCRIPTION
This removes the usage of `apollos` as a command in favor of `npm <command>`
1. `npm start` === run in web mode
2. `npm run native` === run in native mode
3. `npm run device` === run in iOS simulator
   ... more to document
4. `npm test`
