### PR TITLE
Improve accessibility in modals

### DIFF
--- a/imports/blocks/add-schedule/Layout.js
+++ b/imports/blocks/add-schedule/Layout.js
@@ -181,6 +181,7 @@ class Layout extends Component {
               disabled={disableCheckout}
               onClick={onSubmitSchedule}
               text={text || "Schedule Now"}
+              disabledGuest
             />
           </div>
         </Forms.Form>

--- a/imports/blocks/add-schedule/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/add-schedule/__tests__/__snapshots__/Layout.js.snap
@@ -96,6 +96,7 @@ exports[`Layout disables checkout when not ready 1`] = `
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={true}
+        disabledGuest={true}
         text="Schedule Now" />
     </div>
   </Form>
@@ -200,6 +201,7 @@ exports[`Layout disables checkout when total is negative 1`] = `
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={true}
+        disabledGuest={true}
         text="Schedule Now" />
     </div>
   </Form>
@@ -304,6 +306,7 @@ exports[`Layout disables checkout when total is positive but not ready 1`] = `
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={true}
+        disabledGuest={true}
         text="Schedule Now" />
     </div>
   </Form>
@@ -408,6 +411,7 @@ exports[`Layout disables checkout when total is undefined 1`] = `
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={true}
+        disabledGuest={true}
         text="Schedule Now" />
     </div>
   </Form>
@@ -512,6 +516,7 @@ exports[`Layout enables checkout when total is positive and ready 1`] = `
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={false}
+        disabledGuest={true}
         text="Schedule Now" />
     </div>
   </Form>
@@ -618,6 +623,7 @@ exports[`Layout renders the prefilled amount for an existing schedule 1`] = `
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={false}
+        disabledGuest={true}
         text="Schedule Now" />
     </div>
   </Form>
@@ -722,6 +728,7 @@ exports[`Layout renders the prefilled date for an existing schedule  1`] = `
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={false}
+        disabledGuest={true}
         text="Schedule Now" />
     </div>
   </Form>
@@ -826,6 +833,7 @@ exports[`Layout renders the prefilled frequency for an existing schedule  1`] = 
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={false}
+        disabledGuest={true}
         text="Schedule Now" />
     </div>
   </Form>
@@ -930,6 +938,7 @@ exports[`Layout renders the prefilled fund for an existing schedule  1`] = `
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={false}
+        disabledGuest={true}
         text="Schedule Now" />
     </div>
   </Form>
@@ -1034,6 +1043,7 @@ exports[`Layout renders when accounts & state exist 1`] = `
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={true}
+        disabledGuest={true}
         text="Schedule Now" />
     </div>
   </Form>
@@ -1138,6 +1148,7 @@ exports[`Layout renders with custom text 1`] = `
       className="push-top">
       <Connect(Apollo(CheckoutButton))
         disabled={true}
+        disabledGuest={true}
         text="Make Schedules Now" />
     </div>
   </Form>

--- a/imports/blocks/give/Err.js
+++ b/imports/blocks/give/Err.js
@@ -55,7 +55,7 @@ type IErr = {
 };
 
 const Err = ({ msg, goToStepOne, additionalMessage }: IErr) => (
-  <div className="soft soft-double-ends push-double-top one-whole text-center">
+  <div className="soft soft-double-ends push-double-top@anchored one-whole text-center">
     <div className="push-double-top">
       <Error />
       <h3 className="text-alert push-ends">{ERROR_HEADING}</h3>

--- a/imports/blocks/give/Layout.js
+++ b/imports/blocks/give/Layout.js
@@ -92,7 +92,7 @@ const Layout = ({
     <Forms.Form
       id="give"
       theme="hard"
-      fieldsetTheme="flush soft-top scrollable soft-double-bottom"
+      fieldsetTheme="flush soft-top@handheld scrollable soft-double-bottom"
       method="POST"
       submit={onSubmit}
     >

--- a/imports/blocks/give/Success.js
+++ b/imports/blocks/give/Success.js
@@ -104,7 +104,7 @@ const Success = ({
 }: ISuccess) => {
   const schedule = (schedules && schedules.length > 0) ? schedules[0] : false;
   return (
-    <div className="soft soft-double-ends push-double-top one-whole text-center">
+    <div className="soft soft-double-ends push-double-top@anchored one-whole text-center">
       <div className="push-double-top">
         <SuccessIcon />
         <h3 className="text-primary push-ends">Success!</h3>

--- a/imports/blocks/give/__tests__/__snapshots__/Err.js.snap
+++ b/imports/blocks/give/__tests__/__snapshots__/Err.js.snap
@@ -33,7 +33,7 @@ exports[`ContactUs renders 1`] = `
 
 exports[`Err renders 1`] = `
 <div
-  className="soft soft-double-ends push-double-top one-whole text-center">
+  className="soft soft-double-ends push-double-top@anchored one-whole text-center">
   <div
     className="push-double-top">
     <svg

--- a/imports/blocks/give/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/give/__tests__/__snapshots__/Layout.js.snap
@@ -7,7 +7,7 @@ exports[`test renders Billing form 1`] = `
   onSubmit={[Function]}
   style={undefined}>
   <fieldset
-    className="flush soft-top scrollable soft-double-bottom">
+    className="flush soft-top@handheld scrollable soft-double-bottom">
     <div>
       <div
         className="push-double@lap-and-up push">
@@ -61,7 +61,7 @@ exports[`test renders Billing form 1`] = `
         </p>
       </div>
       <div
-        className="soft">
+        className="soft-sides">
         <div
           className="input"
           data-spec="input-wrapper"
@@ -252,7 +252,7 @@ exports[`test renders Confirm form 1`] = `
   onSubmit={[Function]}
   style={undefined}>
   <fieldset
-    className="flush soft-top scrollable soft-double-bottom">
+    className="flush soft-top@handheld scrollable soft-double-bottom">
     <div>
       <div
         className="push-double@lap-and-up push">
@@ -263,7 +263,7 @@ exports[`test renders Confirm form 1`] = `
         </h4>
       </div>
       <div
-        className="soft">
+        className="soft-sides">
         <h5
           className="text-dark-secodary text-left">
           <small>
@@ -361,7 +361,7 @@ exports[`test renders Confirm form 1`] = `
 
 exports[`test renders Error 1`] = `
 <div
-  className="soft soft-double-ends push-double-top one-whole text-center">
+  className="soft soft-double-ends push-double-top@anchored one-whole text-center">
   <div
     className="push-double-top">
     <svg
@@ -472,7 +472,7 @@ exports[`test renders Payment form 1`] = `
   onSubmit={[Function]}
   style={undefined}>
   <fieldset
-    className="flush soft-top scrollable soft-double-bottom">
+    className="flush soft-top@handheld scrollable soft-double-bottom">
     <div>
       <div
         className="push-double@lap-and-up push">
@@ -740,7 +740,7 @@ exports[`test renders Personal form 1`] = `
   onSubmit={[Function]}
   style={undefined}>
   <fieldset
-    className="flush soft-top scrollable soft-double-bottom">
+    className="flush soft-top@handheld scrollable soft-double-bottom">
     <div>
       <div
         className="push-double@lap-and-up push">
@@ -794,7 +794,7 @@ exports[`test renders Personal form 1`] = `
         </p>
       </div>
       <div
-        className="soft">
+        className="soft-sides">
         <div
           className="grid">
           <div
@@ -919,7 +919,7 @@ exports[`test renders Personal form 1`] = `
 
 exports[`test renders Success 1`] = `
 <div
-  className="soft soft-double-ends push-double-top one-whole text-center">
+  className="soft soft-double-ends push-double-top@anchored one-whole text-center">
   <div
     className="push-double-top">
     <svg

--- a/imports/blocks/give/__tests__/__snapshots__/Success.js.snap
+++ b/imports/blocks/give/__tests__/__snapshots__/Success.js.snap
@@ -76,7 +76,7 @@ exports[`ScheduleThanks renders with props 1`] = `
 
 exports[`Success renders with props 1`] = `
 <div
-  className="soft soft-double-ends push-double-top one-whole text-center">
+  className="soft soft-double-ends push-double-top@anchored one-whole text-center">
   <div
     className="push-double-top">
     <svg

--- a/imports/blocks/give/fieldsets/billing/Layout.js
+++ b/imports/blocks/give/fieldsets/billing/Layout.js
@@ -87,7 +87,7 @@ const Layout = ({
 
     {children}
 
-    <div className="soft">
+    <div className="soft-sides">
 
       <Forms.Input
         name="streetAddress"

--- a/imports/blocks/give/fieldsets/billing/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/give/fieldsets/billing/__tests__/__snapshots__/Layout.js.snap
@@ -23,7 +23,7 @@ exports[`Layout renders US by default 1`] = `
     child
   </span>
   <div
-    className="soft">
+    className="soft-sides">
     <div
       className="input input--active"
       data-spec="input-wrapper"
@@ -227,7 +227,7 @@ exports[`Layout renders your country instead 1`] = `
     child
   </span>
   <div
-    className="soft">
+    className="soft-sides">
     <div
       className="input input--active"
       data-spec="input-wrapper"

--- a/imports/blocks/give/fieldsets/confirm/PaymentOptionsLayout.js
+++ b/imports/blocks/give/fieldsets/confirm/PaymentOptionsLayout.js
@@ -28,7 +28,7 @@ const PaymentOptionsLayout = ({
       <Header />
     </div>
 
-    <div className="soft">
+    <div className="soft-sides">
       {savedAccounts.map((account, key) => (
         <SavedAccount
           account={account}

--- a/imports/blocks/give/fieldsets/confirm/ScheduleLayout.js
+++ b/imports/blocks/give/fieldsets/confirm/ScheduleLayout.js
@@ -69,7 +69,7 @@ const ScheduleLayout = ({
         />
       </div>
 
-      <div className="soft">
+      <div className="soft-sides">
         {scheduleList.map((schedule, key) => (
           <ScheduleItem
             key={key}

--- a/imports/blocks/give/fieldsets/confirm/TransactionLayout.js
+++ b/imports/blocks/give/fieldsets/confirm/TransactionLayout.js
@@ -59,7 +59,7 @@ const TransactionLayout = ({
       />
     </div>
 
-    <div className="soft">
+    <div className="soft-sides">
       <h5 className="text-dark-secodary text-left">
         <small><em>{personal.campus} Campus</em></small>
       </h5>

--- a/imports/blocks/give/fieldsets/confirm/__tests__/__snapshots__/PaymentOptionsLayout.js.snap
+++ b/imports/blocks/give/fieldsets/confirm/__tests__/__snapshots__/PaymentOptionsLayout.js.snap
@@ -8,7 +8,7 @@ exports[`test should render with props 1`] = `
     </h4>
   </div>
   <div
-    className="soft">
+    className="soft-sides">
     <div
       id={undefined}
       onClick={[Function]}

--- a/imports/blocks/give/fieldsets/confirm/__tests__/__snapshots__/ScheduleLayout.js.snap
+++ b/imports/blocks/give/fieldsets/confirm/__tests__/__snapshots__/ScheduleLayout.js.snap
@@ -27,7 +27,7 @@ exports[`ScheduleLayout renders with props 1`] = `
     </span>
   </div>
   <div
-    className="soft">
+    className="soft-sides">
     <div
       className="display-inline-block one-whole">
       <h5

--- a/imports/blocks/give/fieldsets/confirm/__tests__/__snapshots__/TransactionLayout.js.snap
+++ b/imports/blocks/give/fieldsets/confirm/__tests__/__snapshots__/TransactionLayout.js.snap
@@ -22,7 +22,7 @@ exports[`TransactionLayout should render with props 1`] = `
     </span>
   </div>
   <div
-    className="soft">
+    className="soft-sides">
     <h5
       className="text-dark-secodary text-left">
       <small>

--- a/imports/blocks/give/fieldsets/personal/Layout.js
+++ b/imports/blocks/give/fieldsets/personal/Layout.js
@@ -80,7 +80,7 @@ const Layout = ({
 
     {children}
 
-    <div className="soft">
+    <div className="soft-sides">
 
       <div className="grid">
         <div className="grid__item one-half">

--- a/imports/blocks/give/fieldsets/personal/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/give/fieldsets/personal/__tests__/__snapshots__/Layout.js.snap
@@ -23,7 +23,7 @@ exports[`Layout renders with props 1`] = `
     child
   </span>
   <div
-    className="soft">
+    className="soft-sides">
     <div
       className="grid">
       <div

--- a/imports/blocks/modal/Modal.js
+++ b/imports/blocks/modal/Modal.js
@@ -34,6 +34,7 @@ export default class SideModal extends Component {
     modal: PropTypes.object,
     theme: PropTypes.string,
     visible: PropTypes.bool,
+    captureRef: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
@@ -188,7 +189,7 @@ export default class SideModal extends Component {
             className={this.props.theme || this.layoutClasses()}
             style={this.styles()}
           >
-            <div className={this.childClasses()} style={{ height: "100%" }}>
+            <div ref={this.props.captureRef} className={this.childClasses()} style={{ height: "100%" }}>
               <ChildComponent {...props} />
             </div>
           </section>

--- a/imports/blocks/modal/Modal.js
+++ b/imports/blocks/modal/Modal.js
@@ -178,7 +178,7 @@ export default class SideModal extends Component {
     }
 
     return (
-      <div className="panel overlay--solid-dark fixed" id="@@modal" onClick={close} style={this.getContainerStyle()}>
+      <div className="panel overlay--solid-dark fixed" data-side-modal id="@@modal" onClick={close} style={this.getContainerStyle()}>
         <VelocityComponent
           animation={slide}
           duration={300}

--- a/imports/blocks/modal/__tests__/__snapshots__/Modal.js.snap
+++ b/imports/blocks/modal/__tests__/__snapshots__/Modal.js.snap
@@ -23,6 +23,7 @@ exports[`test layoutClasses returns default 1`] = `"hard flush side-panel_x7puo 
 exports[`test overrides with theme 1`] = `
 <div
   className="panel overlay--solid-dark fixed"
+  data-side-modal={true}
   id="@@modal"
   onClick={[Function]}
   style={
@@ -74,6 +75,7 @@ exports[`test overrides with theme 1`] = `
 exports[`test renders with props 1`] = `
 <div
   className="panel overlay--solid-dark fixed"
+  data-side-modal={true}
   id="@@modal"
   onClick={[Function]}
   style={
@@ -142,6 +144,7 @@ Object {
 exports[`test updates styles with mobile styles 1`] = `
 <div
   className="panel overlay--solid-dark fixed"
+  data-side-modal={true}
   id="@@modal"
   onClick={[Function]}
   style={
@@ -193,6 +196,7 @@ exports[`test updates styles with mobile styles 1`] = `
 exports[`test updates styles with non mobile styles 1`] = `
 <div
   className="panel overlay--solid-dark fixed"
+  data-side-modal={true}
   id="@@modal"
   onClick={[Function]}
   style={

--- a/imports/blocks/modal/__tests__/__snapshots__/index.js.snap
+++ b/imports/blocks/modal/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,6 @@
 exports[`test render with props 1`] = `
 <SideModal
+  captureRef={[Function]}
   childClasses={Array []}
   close={[Function]}
   component={Object {}}

--- a/imports/blocks/modal/__tests__/index.js
+++ b/imports/blocks/modal/__tests__/index.js
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
 import { modal as modalActions, nav as navActions } from "../../../store";
 import {
@@ -61,17 +61,17 @@ it("updates nav if not keeping the nav and modal visible", () => {
   expect(navActions.setLevel).toHaveBeenCalledWith("MODAL");
 });
 
-it("adds escape listern if client", () => {
-  document.addEventListener = jest.fn();
-  const wrapper = shallow(generateComponent());
-  wrapper.instance().componentDidMount();
-  expect(document.addEventListener).toHaveBeenCalledTimes(1);
-  expect(document.addEventListener).toHaveBeenCalledWith(
-    "keyup",
-    wrapper.instance().bindEsc,
-    false
-  );
-});
+// it("adds escape listern if client", () => {
+//   document.addEventListener = jest.fn();
+//   const wrapper = shallow(generateComponent());
+//   wrapper.instance().componentDidMount();
+//   expect(document.addEventListener).toHaveBeenCalledTimes(1);
+//   expect(document.addEventListener).toHaveBeenCalledWith(
+//     "keyup",
+//     wrapper.instance().bindEsc,
+//     false
+//   );
+// });
 
 it("updates nav and state if visible, not level modal or down, and not keeping nav", () => {
   navActions.setLevel = jest.fn();
@@ -198,15 +198,6 @@ it("removes key bind and resets color on unmount", () => {
   expect(navActions.resetColor).toHaveBeenCalledTimes(1);
 });
 
-it("bindEsc hides modal if escape key event", () => {
-  modalActions.hide = jest.fn();
-  const wrapper = shallow(generateComponent());
-  wrapper.instance().bindEsc({
-    keyCode: 27,
-  });
-  expect(modalActions.hide).toHaveBeenCalledTimes(1);
-});
-
 it("close hides the modal if modal is the target", () => {
   modalActions.hide = jest.fn();
   const wrapper = shallow(generateComponent());
@@ -229,4 +220,55 @@ it("close does not hide the modal if modal is not the target", () => {
   };
   wrapper.instance().close(mockEvent);
   expect(modalActions.hide).not.toHaveBeenCalled();
+});
+
+it("handles esc key to dispatch closing the modal", () => {
+  Meteor.isClient = true;
+  const mockDispatch = jest.fn();
+
+  const wrapper = mount(generateComponent({
+    dispatch: mockDispatch,
+  }));
+
+  const esc =  new CustomEvent("keydown");
+  esc.keyCode = 27;
+
+  document.dispatchEvent(esc);
+  expect(mockDispatch).toBeCalledWith(modalActions.hide());
+});
+
+it("handles esc key to dispatch closing the modal", () => {
+  const mockDispatch = jest.fn();
+  const wrapper = mount(generateComponent({
+    dispatch: mockDispatch,
+  }));
+
+  const { handleKeyPress } = wrapper.instance();
+
+  handleKeyPress({ keyCode: 27 });
+   expect(mockDispatch).toBeCalledWith(modalActions.hide());
+});
+
+it("handles down key to scroll within the component", () => {
+  const scrollElement = { scrollTop: 0 };
+
+  const wrapper = shallow(generateComponent());
+
+  const { handleKeyPress, captureRef } = wrapper.instance();
+  captureRef(scrollElement);
+
+  handleKeyPress({ keyCode: 40 });
+  expect(scrollElement.scrollTop).toBe(10);
+});
+
+it("handles down key to scroll within the component", () => {
+  const scrollElement = { scrollTop: 0 };
+
+  const wrapper = shallow(generateComponent());
+
+  const { handleKeyPress, captureRef } = wrapper.instance();
+  captureRef(scrollElement);
+
+  handleKeyPress({ keyCode: 38 });
+  expect(scrollElement.scrollTop).toBe(-10);
 });

--- a/imports/blocks/modal/index.js
+++ b/imports/blocks/modal/index.js
@@ -25,7 +25,7 @@ class SideModalContainerWithoutData extends Component {
     }
 
     if (Meteor.isClient) {
-      document.addEventListener("keyup", this.bindEsc, false);
+      document.addEventListener("keydown", this.handleKeyPress, false);
     }
   }
 
@@ -83,21 +83,27 @@ class SideModalContainerWithoutData extends Component {
     this.props.dispatch(navActions.resetColor());
   }
 
-  bindEsc = (event) => {
+  handleKeyPress = ({ keyCode }) => {
     // if key hit is `esc` or template is closed is clicked
-    if (event.keyCode === 27) {
-      this.props.dispatch(modalActions.hide());
-    }
+    if (keyCode === 27) this.props.dispatch(modalActions.hide());
+
+    // down arrow
+    if (keyCode === 40 && this.scrollElement) this.scrollElement.scrollTop += 10;
+
+    // up arrow
+    if (keyCode === 38 && this.scrollElement) this.scrollElement.scrollTop -= 10;
   }
 
   close = (e) => {
     const { target } = e;
     const { id } = target;
-    if (id !== "@@modal") {
-      return;
-    }
+    if (id !== "@@modal") return;
 
     this.props.dispatch(modalActions.hide());
+  }
+
+  captureRef = (ref) => {
+    this.scrollElement = ref;
   }
 
   render() {
@@ -108,6 +114,7 @@ class SideModalContainerWithoutData extends Component {
         component={content}
         props={props}
         visible={visible}
+        captureRef={this.captureRef}
         {...this.props}
       />
     );

--- a/imports/blocks/modal/index.js
+++ b/imports/blocks/modal/index.js
@@ -1,6 +1,7 @@
+
+import { Meteor } from "meteor/meteor";
 import { Component, PropTypes } from "react";
 import { connect } from "react-redux";
-import { Meteor } from "meteor/meteor";
 
 import { modal as modalActions, nav as navActions } from "../../store";
 
@@ -14,6 +15,7 @@ class SideModalContainerWithoutData extends Component {
     navigation: PropTypes.object, // eslint-disable-line
     path: PropTypes.string,
   }
+
 
   state = {
     previous: null,

--- a/imports/router/server/index.js
+++ b/imports/router/server/index.js
@@ -5,14 +5,13 @@ import cookieParser from "cookie-parser";
 import { StyleSheetServer } from "aphrodite";
 import ReactHelmet from "react-helmet";
 import Cheerio from "cheerio/lib/cheerio";
-import MinReact from "react/dist/react.min";
+import ReactDOMServer from "react-dom/server";
 import { getDataFromTree } from "react-apollo/server";
 import { GraphQL } from "../../graphql";
 import InjectData from "./inject-data";
 import SSRContext from "./context";
 import patchSubscribeData from "./data";
 
-const ReactDOMServer = MinReact.__SECRET_DOM_SERVER_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
 const ReactRouterSSR = {};
 const cache = {}; // in memory cache of static markup

--- a/stylesheets/_hacks.scss
+++ b/stylesheets/_hacks.scss
@@ -124,3 +124,10 @@ blockquote p {
     background-color: map-get($colors, "dark-secondary");
   }
 }
+
+// inputs in modals are too spaced out
+[data-side-modal] {
+  .input {
+    padding-bottom: 40px;
+  }
+}


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Tightend input padding within the modal to reduce overall form height
- Bound up and down keypress to scroll within the modal. Yay accessibility 

# Testing/Documentation
- [x] All significant new logic is covered by tests.

# Screenshots
*before*
<img width="1280" alt="screen shot 2016-11-20 at 11 37 12 am" src="https://cloud.githubusercontent.com/assets/4967600/20464448/c9f4e66c-af15-11e6-9d4a-1f55a613babe.png">
*after*
<img width="1280" alt="screen shot 2016-11-20 at 11 37 24 am" src="https://cloud.githubusercontent.com/assets/4967600/20464449/c9f5a264-af15-11e6-8f0d-889a5e63f393.png">


# QA Process
#### To test:
[on beta](https://beta-my.newspring.cc/give/now)
- [ ] giving UI works on all devices
- [ ] scrolling is possible within modals
- [ ] up and down arrow scrolls within a modal
- [ ] billing fields are all visible on all landscape devices* (this one may not be possible?)

All new features and fixes should be tested and signed off on in the [device testing document](https://docs.google.com/spreadsheets/d/1TG0jmltkp61oRA4nYpcoGFTh1lDxa1A8dSnitBKT0lk/edit#gid=1270385294) that corresponds to this PR. **This PR should be tested and PASS on all devices/breakpoints prior to merging.**

# Reporting Bugs
If you find an issue, a bug, or something that seems weird, thank you! That is extremely helpful. You can report this kind of feedback using our [GitHub Issues page](https://github.com/NewSpring/Holtzman/issues). Here are a few things that are great to include in an issue:

- Reference to this pull request.
- Steps to reproduce the issue
- Explanation of the buggy behavior
- Explanation of the expected behavior
- Screenshots of the app if helpful

Here is a link to a [good example issue.](https://github.com/NewSpring/Apollos/issues/841)