### PR TITLE
Final giving tweaks / bugs

### DIFF
--- a/imports/blocks/add-schedule/Layout.js
+++ b/imports/blocks/add-schedule/Layout.js
@@ -182,7 +182,7 @@ class Layout extends Component {
             <CheckoutButtons
               disabled={disableCheckout}
               onClick={onSubmitSchedule}
-              text={text || "Schedule Now"}
+              text={text || "Review Schedule"}
               dataId={dataId}
               disabledGuest
             />

--- a/imports/blocks/add-schedule/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/add-schedule/__tests__/__snapshots__/Layout.js.snap
@@ -97,7 +97,7 @@ exports[`Layout disables checkout when not ready 1`] = `
       <Connect(Apollo(CheckoutButton))
         disabled={true}
         disabledGuest={true}
-        text="Schedule Now" />
+        text="Review Schedule" />
     </div>
   </Form>
 </div>
@@ -202,7 +202,7 @@ exports[`Layout disables checkout when total is negative 1`] = `
       <Connect(Apollo(CheckoutButton))
         disabled={true}
         disabledGuest={true}
-        text="Schedule Now" />
+        text="Review Schedule" />
     </div>
   </Form>
 </div>
@@ -307,7 +307,7 @@ exports[`Layout disables checkout when total is positive but not ready 1`] = `
       <Connect(Apollo(CheckoutButton))
         disabled={true}
         disabledGuest={true}
-        text="Schedule Now" />
+        text="Review Schedule" />
     </div>
   </Form>
 </div>
@@ -412,7 +412,7 @@ exports[`Layout disables checkout when total is undefined 1`] = `
       <Connect(Apollo(CheckoutButton))
         disabled={true}
         disabledGuest={true}
-        text="Schedule Now" />
+        text="Review Schedule" />
     </div>
   </Form>
 </div>
@@ -517,7 +517,7 @@ exports[`Layout enables checkout when total is positive and ready 1`] = `
       <Connect(Apollo(CheckoutButton))
         disabled={false}
         disabledGuest={true}
-        text="Schedule Now" />
+        text="Review Schedule" />
     </div>
   </Form>
 </div>
@@ -624,7 +624,7 @@ exports[`Layout renders the prefilled amount for an existing schedule 1`] = `
       <Connect(Apollo(CheckoutButton))
         disabled={false}
         disabledGuest={true}
-        text="Schedule Now" />
+        text="Review Schedule" />
     </div>
   </Form>
 </div>
@@ -729,7 +729,7 @@ exports[`Layout renders the prefilled date for an existing schedule  1`] = `
       <Connect(Apollo(CheckoutButton))
         disabled={false}
         disabledGuest={true}
-        text="Schedule Now" />
+        text="Review Schedule" />
     </div>
   </Form>
 </div>
@@ -834,7 +834,7 @@ exports[`Layout renders the prefilled frequency for an existing schedule  1`] = 
       <Connect(Apollo(CheckoutButton))
         disabled={false}
         disabledGuest={true}
-        text="Schedule Now" />
+        text="Review Schedule" />
     </div>
   </Form>
 </div>
@@ -939,7 +939,7 @@ exports[`Layout renders the prefilled fund for an existing schedule  1`] = `
       <Connect(Apollo(CheckoutButton))
         disabled={false}
         disabledGuest={true}
-        text="Schedule Now" />
+        text="Review Schedule" />
     </div>
   </Form>
 </div>
@@ -1044,7 +1044,7 @@ exports[`Layout renders when accounts & state exist 1`] = `
       <Connect(Apollo(CheckoutButton))
         disabled={true}
         disabledGuest={true}
-        text="Schedule Now" />
+        text="Review Schedule" />
     </div>
   </Form>
 </div>

--- a/imports/blocks/give/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/give/__tests__/__snapshots__/Layout.js.snap
@@ -313,7 +313,7 @@ exports[`test renders Confirm form 1`] = `
           className="btn soft-half-top one-whole"
           type="submit">
           <span>
-            Give Now
+            Give
           </span>
            
           <div

--- a/imports/blocks/give/fieldsets/confirm/__tests__/__snapshots__/ScheduleLayout.js.snap
+++ b/imports/blocks/give/fieldsets/confirm/__tests__/__snapshots__/ScheduleLayout.js.snap
@@ -72,7 +72,7 @@ exports[`ScheduleLayout renders with props 1`] = `
       className="btn one-whole push-top soft-sides"
       type="submit">
       <span>
-        Schedule Now using 6789
+        Schedule using 6789
       </span>
        
       <div

--- a/imports/blocks/give/fieldsets/confirm/__tests__/__snapshots__/TransactionLayout.js.snap
+++ b/imports/blocks/give/fieldsets/confirm/__tests__/__snapshots__/TransactionLayout.js.snap
@@ -142,7 +142,7 @@ exports[`TransactionLayout should render with props 1`] = `
       className="btn soft-half-top one-whole"
       type="submit">
       <span>
-        Give Now using 6789
+        Give using 6789
       </span>
        
       <div

--- a/imports/blocks/give/fieldsets/shared/BankFields.js
+++ b/imports/blocks/give/fieldsets/shared/BankFields.js
@@ -48,7 +48,7 @@ const BankFields = ({
             label="Account Type"
             onChange={saveData}
             validation={validate}
-            defaultValue={payment.accountType}
+            defaultValue={payment.accountType || "checking"}
             errorText="Please choose your account type"
             includeBlank
             items={[

--- a/imports/blocks/give/fieldsets/shared/ButtonText.js
+++ b/imports/blocks/give/fieldsets/shared/ButtonText.js
@@ -20,14 +20,14 @@ const ButtonText = ({
     paymentInfo.type = "ach";
   }
 
-  let text = "Give Now";
+  let text = "Give";
 
-  if (Object.keys(schedules).length) text = "Schedule Now";
-  if (scheduleToRecover) text = "Transfer Now";
+  if (Object.keys(schedules).length) text = "Schedule";
+  if (scheduleToRecover) text = "Transfer";
 
   if (paymentInfo.accountNumber || paymentInfo.cardNumber) {
     const masked = paymentInfo.type === "ach" ? paymentInfo.accountNumber : paymentInfo.cardNumber;
-    text += ` using ${masked.slice(-4)}`;
+    text += ` using ${masked.replace(/-/g, "").slice(-4)}`;
   }
 
   return <span>{text}</span>;

--- a/imports/blocks/give/fieldsets/shared/__tests__/__snapshots__/ActionButton.js.snap
+++ b/imports/blocks/give/fieldsets/shared/__tests__/__snapshots__/ActionButton.js.snap
@@ -21,7 +21,7 @@ exports[`test should render web action button 1`] = `
   className="btn soft-half-top one-whole"
   type="submit">
   <span>
-    Give Now using 6789
+    Give using 6789
   </span>
    
   <div

--- a/imports/blocks/give/fieldsets/shared/__tests__/__snapshots__/ButtonText.js.snap
+++ b/imports/blocks/give/fieldsets/shared/__tests__/__snapshots__/ButtonText.js.snap
@@ -1,53 +1,53 @@
 exports[`test should say \`Give Now using 4321\` if cardNumber 1`] = `
 <span>
-  Give Now using 4321
+  Give using 4321
 </span>
 `;
 
 exports[`test should say \`Give Now using 6789\` if accountNumber 1`] = `
 <span>
-  Give Now using 6789
+  Give using 6789
 </span>
 `;
 
 exports[`test should say \`Give Now\` with minimal props 1`] = `
 <span>
-  Give Now
+  Give
 </span>
 `;
 
 exports[`test should say \`Schedule Now using 4321\` if schedule and cardNumber 1`] = `
 <span>
-  Schedule Now using 4321
+  Schedule using 4321
 </span>
 `;
 
 exports[`test should say \`Schedule Now using 6789\` if schedule and accountNumber 1`] = `
 <span>
-  Schedule Now using 6789
+  Schedule using 6789
 </span>
 `;
 
 exports[`test should say \`Schedule Now\` if schedule present 1`] = `
 <span>
-  Schedule Now
+  Schedule
 </span>
 `;
 
 exports[`test should say \`Transfer Now using 4321\` if schedule and cardNumber 1`] = `
 <span>
-  Transfer Now using 4321
+  Transfer using 4321
 </span>
 `;
 
 exports[`test should say \`Transfer Now using 6789\` if recoverable schedule and accountNumber 1`] = `
 <span>
-  Transfer Now using 6789
+  Transfer using 6789
 </span>
 `;
 
 exports[`test should say \`Transfer Now\` if recoverable schedule 1`] = `
 <span>
-  Transfer Now
+  Transfer
 </span>
 `;

--- a/imports/pages/give/schedules/Layout.js
+++ b/imports/pages/give/schedules/Layout.js
@@ -23,6 +23,10 @@ export default class Layout extends Component {
     person: PropTypes.object,
   }
 
+  static defaultProps = {
+    schedules: [],
+  }
+
   state = {
     expandedSchedule: null,
   }

--- a/imports/pages/give/schedules/Layout.js
+++ b/imports/pages/give/schedules/Layout.js
@@ -49,8 +49,10 @@ export default class Layout extends Component {
     });
   }
 
+  // XXX this is a timezone related formatting issue
+  // so add a day to show correct dates
   formatDate = (date) => (
-    moment(new Date(date)).add(4, "hours").format("MMM D, YYYY")
+    moment(date).add(1, "day").format("MMM D, YYYY")
   )
 
   capitalizeFirstLetter = (string) => (
@@ -191,10 +193,9 @@ export default class Layout extends Component {
                     if (!schedule.details || !schedule.details[0].account) {
                       return null;
                     }
-
                     const complete = false;
                     if (
-                      new Date(schedule.next) < moment().add(1, "day") &&
+                      moment(schedule.next).add(1, "day") < moment().add(1, "day") &&
                       schedule.schedule.value === "One-Time"
                     ) {
                       hasCompletedSchedules = true;

--- a/imports/pages/give/schedules/Layout.js
+++ b/imports/pages/give/schedules/Layout.js
@@ -304,7 +304,7 @@ export default class Layout extends Component {
 
                       let complete = false;
                       if (
-                        new Date(schedule.next) < moment().add(1, "day") &&
+                        moment(schedule.next).add(1, "day") < moment().add(1, "day") &&
                         schedule.schedule.value === "One-Time"
                       ) {
                         complete = true;

--- a/imports/pages/give/schedules/Recover/index.js
+++ b/imports/pages/give/schedules/Recover/index.js
@@ -88,7 +88,7 @@ const SCHEDULED_TRANSACTIONS_QUERY = gql`
       payment { paymentType, accountNumber, id }
       schedule { value, description }
     }
-    person: currentPerson { firstName, lastName }
+    person: currentPerson { nickName, firstName, lastName }
   }
 `;
 

--- a/imports/pages/give/schedules/__tests__/Layout.js
+++ b/imports/pages/give/schedules/__tests__/Layout.js
@@ -357,7 +357,7 @@ it("collapseSchedule sets state to null", () => {
 it("formatDate returns a formatted data", () => {
   const wrapper = shallow(generateComponent());
   const result = wrapper.instance().formatDate("12-12-2012");
-  expect(result).toBe("Dec 12, 2012");
+  expect(result).toBe("Dec 13, 2012");
 });
 
 it("capitalizeFirstLetter does that", () => {

--- a/imports/pages/give/schedules/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/pages/give/schedules/__tests__/__snapshots__/Layout.js.snap
@@ -112,7 +112,7 @@ exports[`test doesn't render incompleted schedule as completed schedule 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 2012
+                      Dec 13, 2012
                     </em>
                   </small>
                 </p>
@@ -209,7 +209,7 @@ exports[`test doesn't render incompleted schedule as completed schedule 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 1999
+                      Dec 13, 1999
                     </em>
                   </small>
                 </p>
@@ -385,7 +385,7 @@ exports[`test doesn't render one time completed schedule if no details 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 1999
+                      Dec 13, 1999
                     </em>
                   </small>
                 </p>
@@ -561,7 +561,7 @@ exports[`test doesn't render one time completed schedule if no details account 1
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 1999
+                      Dec 13, 1999
                     </em>
                   </small>
                 </p>
@@ -897,7 +897,7 @@ exports[`test renders loading if accounts not ready 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 2012
+                      Dec 13, 2012
                     </em>
                   </small>
                 </p>
@@ -1067,7 +1067,7 @@ exports[`test renders loading if no accounts 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 2012
+                      Dec 13, 2012
                     </em>
                   </small>
                 </p>
@@ -1237,7 +1237,7 @@ exports[`test renders loading if no accounts 2`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 2012
+                      Dec 13, 2012
                     </em>
                   </small>
                 </p>
@@ -1593,7 +1593,7 @@ exports[`test renders one time completed schedules 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 1999
+                      Dec 13, 1999
                     </em>
                   </small>
                 </p>
@@ -1836,7 +1836,7 @@ exports[`test renders with props 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 2012
+                      Dec 13, 2012
                     </em>
                   </small>
                 </p>
@@ -2002,7 +2002,7 @@ exports[`test renders without schedule details 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 2012
+                      Dec 13, 2012
                     </em>
                   </small>
                 </p>
@@ -2168,7 +2168,7 @@ exports[`test renders without schedule details account 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 2012
+                      Dec 13, 2012
                     </em>
                   </small>
                 </p>
@@ -2334,7 +2334,7 @@ exports[`test works with nickName 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 2012
+                      Dec 13, 2012
                     </em>
                   </small>
                 </p>
@@ -2477,7 +2477,7 @@ exports[`test works without recoverableSchedules 1`] = `
                   className="flush soft-half-top text-dark-tertiary">
                   <small>
                     <em>
-                      Dec 11, 2012
+                      Dec 13, 2012
                     </em>
                   </small>
                 </p>

--- a/imports/pages/give/schedules/index.js
+++ b/imports/pages/give/schedules/index.js
@@ -26,6 +26,12 @@ class TemplateWithoutData extends Component {
     give: PropTypes.object,
   }
 
+  static defaultProps = {
+    schedules: {
+      schedules: [],
+    },
+  }
+
   componentDidMount() {
     if (process.env.NATIVE) {
       const item = { title: "Schedule Your Giving" };
@@ -109,6 +115,7 @@ const SCHEDULED_TRANSACTIONS_QUERY = gql`
 `;
 
 const withScheduledTransactions = graphql(SCHEDULED_TRANSACTIONS_QUERY, {
+  skip: (ownProps) => !ownProps.authorized,
   options: { ssr: false, forceFetch: true },
   name: "schedules",
 });
@@ -132,13 +139,14 @@ const withFinancialAccounts = graphql(FINANCIAL_ACCOUNTS_QUERY, {
   name: "accounts",
 });
 
-const mapStateToProps = (store) => ({
-  give: store.give,
+const mapStateToProps = ({ give, accounts }) => ({
+  give,
+  authorized: accounts.authorized,
 });
 
-const Template = withFinancialAccounts(
-  withScheduledTransactions(
-    connect(mapStateToProps)(
+const Template = connect(mapStateToProps)(
+  withFinancialAccounts(
+    withScheduledTransactions(
       TemplateWithoutData
     )
   )

--- a/imports/pages/give/schedules/index.js
+++ b/imports/pages/give/schedules/index.js
@@ -82,6 +82,7 @@ const SCHEDULED_TRANSACTIONS_QUERY = gql`
       next
       end
       id
+      entityId
       reminderDate
       code
       gateway
@@ -107,8 +108,9 @@ const SCHEDULED_TRANSACTIONS_QUERY = gql`
   }
 `;
 
-const withScheduledTransactions = graphql(SCHEDULED_TRANSACTIONS_QUERY, { name: "schedules" }, {
-  options: { ssr: false },
+const withScheduledTransactions = graphql(SCHEDULED_TRANSACTIONS_QUERY, {
+  options: { ssr: false, forceFetch: true },
+  name: "schedules",
 });
 
 const FINANCIAL_ACCOUNTS_QUERY = gql`
@@ -125,16 +127,17 @@ const FINANCIAL_ACCOUNTS_QUERY = gql`
   }
 `;
 
-const withFinancialAccounts = graphql(FINANCIAL_ACCOUNTS_QUERY, { name: "accounts" }, {
+const withFinancialAccounts = graphql(FINANCIAL_ACCOUNTS_QUERY, {
   options: { ssr: true },
+  name: "accounts",
 });
 
 const mapStateToProps = (store) => ({
   give: store.give,
 });
 
-const Template = withScheduledTransactions(
-  withFinancialAccounts(
+const Template = withFinancialAccounts(
+  withScheduledTransactions(
     connect(mapStateToProps)(
       TemplateWithoutData
     )


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- [x] Entering new payment isn't cleared when exiting modal
- [x] Entering new card, shows last 3 instead of last 4 in give button
- [x] Saved payment doesn't always save custom name?
- [x] Schedule for tomorrow is marked complete on schedule list, though I still have ability to stop on the detail screen. Date is one day prior.
- [x] Even after Remind me later confirmation, schedule keeps popping up on subsequent visits.
- [x] Can we default to check account under bank account entry?
- [x] Transfer schedule page uses first name instead of nickname
- [x] Cancelled schedules are coming back asking to be transferred
- [x] When scheduling, button should say review schedule.

# Testing/Documentation
- [x] All significant new logic is covered by tests.
- [x] Storybook documentation has been added.

# Screenshots
- If applicable, include screenshots of UI/style changes.

# QA Process
All new features and fixes should be tested and signed off on in the [device testing document](https://docs.google.com/spreadsheets/d/1TG0jmltkp61oRA4nYpcoGFTh1lDxa1A8dSnitBKT0lk/edit#gid=1270385294) that corresponds to this PR. **This PR should be tested and PASS on all devices/breakpoints prior to merging.**

# Reporting Bugs
If you find an issue, a bug, or something that seems weird, thank you! That is extremely helpful. You can report this kind of feedback using our [GitHub Issues page](https://github.com/NewSpring/Holtzman/issues). Here are a few things that are great to include in an issue:

- Reference to this pull request.
- Steps to reproduce the issue
- Explanation of the buggy behavior
- Explanation of the expected behavior
- Screenshots of the app if helpful

Here is a link to a [good example issue.](https://github.com/NewSpring/Apollos/issues/841)
