### PR TITLE
fixed component styles and flow types

### DIFF
--- a/imports/components/buttons/small.js
+++ b/imports/components/buttons/small.js
@@ -7,7 +7,7 @@ type ISmallButton = {
   linkUrl?: string,
   onClick?: Function,
   disabled?: Boolean,
-  text: String,
+  text: string,
   className?: string,
   style?: Object,
 };

--- a/imports/components/cards/__tests__/__snapshots__/cards.Activity.js.snap
+++ b/imports/components/cards/__tests__/__snapshots__/cards.Activity.js.snap
@@ -21,7 +21,7 @@ exports[`Activity should render the failed status component 1`] = `
       You did something awesome and I\'ve never been more proud.
     </p>
     <Link
-      className="text-light-primary"
+      className="text-light-primary plain"
       onlyActiveOnIndex={false}
       style={Object {}}
       to="https://my.newspring.cc/give/now">
@@ -59,7 +59,7 @@ exports[`Activity should render the warning status component 1`] = `
       You did something awesome and I\'ve never been more proud.
     </p>
     <Link
-      className="text-light-primary"
+      className="text-light-primary plain"
       onlyActiveOnIndex={false}
       style={Object {}}
       to="https://my.newspring.cc/give/now">
@@ -97,7 +97,7 @@ exports[`Activity should render with the default set of props 1`] = `
       You did something awesome and I\'ve never been more proud.
     </p>
     <Link
-      className="text-light-primary"
+      className="text-light-primary plain"
       onlyActiveOnIndex={false}
       style={Object {}}
       to="https://my.newspring.cc/give/now">

--- a/imports/components/cards/cards.Activity.js
+++ b/imports/components/cards/cards.Activity.js
@@ -55,7 +55,7 @@ const Activity = ({
       </div>
       <p>{message}</p>
       {linkText && linkUrl &&
-        <Link to={linkUrl} className="text-light-primary">
+        <Link to={linkUrl} className="text-light-primary plain">
           <h5 className="display-inline-block">{linkText}</h5><span className="icon-arrow-next soft-half-left" />
         </Link>
       }


### PR DESCRIPTION
This PR fixes 2 small issues

1. On SmallButton, the `text` flowtype was `String` and should be `string`
2. On ActivityCard, the link arrow has an underline that we didn't see in storybook since it doesn't work well with linking. I added the `plain` class to the `Link` to fix that. 
