### PR TITLE
SYS-2577 fixes switching to give now, and back to dashboard

### DIFF
--- a/imports/pages/give/now/index.js
+++ b/imports/pages/give/now/index.js
@@ -30,6 +30,13 @@ class PageWithoutData extends Component {
     }
   }
 
+  componentWillUnmount() {
+    this.props.setRightProps({
+      background: "",
+      link: "",
+    });
+  }
+
   render() {
     return <Layout {...this.props} />;
   }


### PR DESCRIPTION
@jbaxleyiii Found it.

### Steps to reproduce original bug

- From Dashboard click Give Now
- Click Home

### Defect

Once done, the svg does not repaint, text is centered, and the entire right panel is a link.

### Fix

The give now right panel was not removing the link on unmount.  I've cleared out the props on unmount and that fixes the problem.