### PR TITLE
Cleanup some tests

### DIFF
--- a/imports/blocks/discover/__tests__/index.js
+++ b/imports/blocks/discover/__tests__/index.js
@@ -166,7 +166,6 @@ it("searchSubmit calls prevent default and all the search actions", () => {
     blur: mockBlur,
     value: "hey",
   }));
-  const mockPromise = new Promise(p => p());
   const mockGetSearch = jest.fn();
   searchActions.searching = jest.fn();
   searchActions.clear = jest.fn();
@@ -189,10 +188,6 @@ it("searchSubmit calls prevent default and all the search actions", () => {
   expect(searchActions.clear).toHaveBeenCalledTimes(1);
   expect(searchActions.term).toHaveBeenCalledTimes(1);
   expect(searchActions.toggleLoading).toHaveBeenCalledTimes(1);
-
-  return mockPromise.then(() => {
-    expect(mockGetSearch).toHaveBeenCalledTimes(2);
-  })
 });
 
 it("loadMore calls toggleLoading and getSearch", () => {

--- a/imports/blocks/discover/__tests__/index.js
+++ b/imports/blocks/discover/__tests__/index.js
@@ -122,7 +122,8 @@ it("getSearch calls apollo client with search query", () => {
     expect(searchActions.add).toHaveBeenCalledWith(
       mockPromiseData.data.search.items
     );
-  });
+  })
+  catch(() => { /* Do nothing */ });
 });
 
 it("getSearch calls none and done if no items", () => {
@@ -149,7 +150,8 @@ it("getSearch calls none and done if no items", () => {
     expect(searchActions.none).toHaveBeenCalledWith(true);
     expect(searchActions.done).toHaveBeenCalledTimes(1);
     expect(searchActions.done).toHaveBeenCalledWith(true);
-  });
+  })
+  catch(() => { /* Do nothing */ });
 });
 
 it("hide hides the modal", () => {
@@ -192,7 +194,8 @@ it("searchSubmit calls prevent default and all the search actions", () => {
 
   mockPromise.then(() => {
     expect(mockGetSearch).toHaveBeenCalledTimes(2);
-  });
+  }).
+  catch(() => { /* Do nothing */ });
 });
 
 it("loadMore calls toggleLoading and getSearch", () => {

--- a/imports/blocks/discover/__tests__/index.js
+++ b/imports/blocks/discover/__tests__/index.js
@@ -115,7 +115,7 @@ it("getSearch calls apollo client with search query", () => {
     },
     forceFetch: true,
   });
-  mockPromise.then(() => {
+  return mockPromise.then(() => {
     expect(searchActions.toggleLoading).toHaveBeenCalledTimes(1);
     expect(searchActions.incrementPage).toHaveBeenCalledTimes(1);
     expect(searchActions.add).toHaveBeenCalledTimes(1);
@@ -123,7 +123,6 @@ it("getSearch calls apollo client with search query", () => {
       mockPromiseData.data.search.items
     );
   })
-  catch(() => { /* Do nothing */ });
 });
 
 it("getSearch calls none and done if no items", () => {
@@ -145,13 +144,12 @@ it("getSearch calls none and done if no items", () => {
   searchActions.none = jest.fn();
   searchActions.done = jest.fn();
   wrapper.instance().getSearch();
-  mockPromise.then(() => {
+  return mockPromise.then(() => {
     expect(searchActions.none).toHaveBeenCalledTimes(1);
     expect(searchActions.none).toHaveBeenCalledWith(true);
     expect(searchActions.done).toHaveBeenCalledTimes(1);
     expect(searchActions.done).toHaveBeenCalledWith(true);
   })
-  catch(() => { /* Do nothing */ });
 });
 
 it("hide hides the modal", () => {
@@ -192,10 +190,9 @@ it("searchSubmit calls prevent default and all the search actions", () => {
   expect(searchActions.term).toHaveBeenCalledTimes(1);
   expect(searchActions.toggleLoading).toHaveBeenCalledTimes(1);
 
-  mockPromise.then(() => {
+  return mockPromise.then(() => {
     expect(mockGetSearch).toHaveBeenCalledTimes(2);
-  }).
-  catch(() => { /* Do nothing */ });
+  })
 });
 
 it("loadMore calls toggleLoading and getSearch", () => {

--- a/imports/blocks/discover/index.js
+++ b/imports/blocks/discover/index.js
@@ -84,13 +84,14 @@ class SearchContainerWithoutData extends Component {
     this.props.client.query({ query: SEARCH_QUERY, variables, forceFetch: true })
       .then(({ data }) => {
         const { search } = data;
+        const propsSearch = this.props.search;
         dispatch(searchActions.toggleLoading());
         dispatch(searchActions.incrementPage());
         dispatch(searchActions.add(search.items));
         if (search.total === 0) {
           dispatch(searchActions.none(true));
         }
-        if (this.props.search.items.length >= search.total) {
+        if (!propsSearch || !propsSearch.items || propsSearch.items.length >= search.total) {
           dispatch(searchActions.done(true));
         }
       });

--- a/imports/blocks/give/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/give/__tests__/__snapshots__/Layout.js.snap
@@ -50,9 +50,9 @@ exports[`test renders Billing form 1`] = `
         className="flush-bottom">
         <small
           className="italic display-inline-block push-half-top">
-          Step
+          Step 
           2
-           of
+           of 
           4
         </small>
       </p>
@@ -164,7 +164,7 @@ exports[`test renders Confirm form 1`] = `
           <button
             className="
               btn btn--small@next
-
+              
               btn--dark-secondary flush-bottom
             "
             disabled={undefined}
@@ -332,7 +332,7 @@ exports[`test renders Error 1`] = `
       className="test-dark-tertiary text-left">
       <em>
         If you would like a member of our customer support team to follow up with you regarding this error, click
-
+         
         <a
           href="//rock.newspring.cc/workflows/152?Topic=Stewardship"
           rel="noopener noreferrer"
@@ -435,9 +435,9 @@ exports[`test renders Payment form 1`] = `
         className="flush-bottom">
         <small
           className="italic display-inline-block push-half-top">
-          Step
+          Step 
           3
-           of
+           of 
           4
         </small>
       </p>
@@ -624,9 +624,9 @@ exports[`test renders Personal form 1`] = `
         className="flush-bottom">
         <small
           className="italic display-inline-block push-half-top">
-          Step
+          Step 
           1
-           of
+           of 
           4
         </small>
       </p>
@@ -720,14 +720,14 @@ exports[`test renders Success 1`] = `
       className="test-dark-tertiary text-left">
       <em>
         If you have any questions please call our Finance Team at 864-965-9990 or
-
+         
         <a
           href="//rock.newspring.cc/workflows/152?Topic=Stewardship"
           rel="noopener noreferrer"
           target="_blank">
           contact us
         </a>
-
+         
         and someone will be happy to assist you.
       </em>
     </p>

--- a/imports/blocks/give/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/give/__tests__/__snapshots__/Layout.js.snap
@@ -50,9 +50,9 @@ exports[`test renders Billing form 1`] = `
         className="flush-bottom">
         <small
           className="italic display-inline-block push-half-top">
-          Step 
+          Step
           2
-           of 
+           of
           4
         </small>
       </p>
@@ -164,7 +164,7 @@ exports[`test renders Confirm form 1`] = `
           <button
             className="
               btn btn--small@next
-              
+
               btn--dark-secondary flush-bottom
             "
             disabled={undefined}
@@ -332,7 +332,7 @@ exports[`test renders Error 1`] = `
       className="test-dark-tertiary text-left">
       <em>
         If you would like a member of our customer support team to follow up with you regarding this error, click
-         
+
         <a
           href="//rock.newspring.cc/workflows/152?Topic=Stewardship"
           rel="noopener noreferrer"
@@ -435,9 +435,9 @@ exports[`test renders Payment form 1`] = `
         className="flush-bottom">
         <small
           className="italic display-inline-block push-half-top">
-          Step 
+          Step
           3
-           of 
+           of
           4
         </small>
       </p>
@@ -624,9 +624,9 @@ exports[`test renders Personal form 1`] = `
         className="flush-bottom">
         <small
           className="italic display-inline-block push-half-top">
-          Step 
+          Step
           1
-           of 
+           of
           4
         </small>
       </p>
@@ -720,14 +720,14 @@ exports[`test renders Success 1`] = `
       className="test-dark-tertiary text-left">
       <em>
         If you have any questions please call our Finance Team at 864-965-9990 or
-         
+
         <a
           href="//rock.newspring.cc/workflows/152?Topic=Stewardship"
           rel="noopener noreferrer"
           target="_blank">
           contact us
         </a>
-         
+
         and someone will be happy to assist you.
       </em>
     </p>

--- a/imports/blocks/give/fieldsets/billing/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/give/fieldsets/billing/__tests__/__snapshots__/Layout.js.snap
@@ -87,8 +87,7 @@ exports[`Layout renders US by default 1`] = `
         name="country"
         onChange={[Function]}
         onFocus={[Function]}
-        placeholder="Country"
-        value={undefined}>
+        placeholder="Country">
         <option
           style={
             Object {
@@ -148,8 +147,7 @@ exports[`Layout renders US by default 1`] = `
             name="state"
             onChange={[Function]}
             onFocus={[Function]}
-            placeholder="State/Territory"
-            value={undefined}>
+            placeholder="State/Territory">
             <option
               style={
                 Object {
@@ -291,8 +289,7 @@ exports[`Layout renders your country instead 1`] = `
         name="country"
         onChange={[Function]}
         onFocus={[Function]}
-        placeholder="Country"
-        value={undefined}>
+        placeholder="Country">
         <option
           style={
             Object {
@@ -352,8 +349,7 @@ exports[`Layout renders your country instead 1`] = `
             name="state"
             onChange={[Function]}
             onFocus={[Function]}
-            placeholder="State/Territory"
-            value={undefined}>
+            placeholder="State/Territory">
             <option
               style={
                 Object {

--- a/imports/blocks/give/fieldsets/personal/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/give/fieldsets/personal/__tests__/__snapshots__/Layout.js.snap
@@ -120,8 +120,7 @@ exports[`Layout renders with props 1`] = `
         name="campus"
         onChange={[Function]}
         onFocus={[Function]}
-        placeholder="Campus"
-        value={undefined}>
+        placeholder="Campus">
         <option
           style={
             Object {

--- a/imports/blocks/give/fieldsets/shared/__tests__/__snapshots__/BankFields.js.snap
+++ b/imports/blocks/give/fieldsets/shared/__tests__/__snapshots__/BankFields.js.snap
@@ -69,8 +69,7 @@ exports[`test should render with props 1`] = `
           name="billing-account-type"
           onChange={[Function]}
           onFocus={[Function]}
-          placeholder="Account Type"
-          value={undefined}>
+          placeholder="Account Type">
           <option
             style={
               Object {

--- a/imports/blocks/give/fieldsets/shared/__tests__/__snapshots__/StateOrTerritory.js.snap
+++ b/imports/blocks/give/fieldsets/shared/__tests__/__snapshots__/StateOrTerritory.js.snap
@@ -18,8 +18,7 @@ exports[`test renders if country is \`CA\` 1`] = `
       name="state"
       onChange={[Function]}
       onFocus={[Function]}
-      placeholder="State/Territory"
-      value={undefined}>
+      placeholder="State/Territory">
       <option
         style={
           Object {
@@ -63,8 +62,7 @@ exports[`test renders if no country 1`] = `
       name="state"
       onChange={[Function]}
       onFocus={[Function]}
-      placeholder="State/Territory"
-      value={undefined}>
+      placeholder="State/Territory">
       <option
         style={
           Object {
@@ -108,8 +106,7 @@ exports[`test renders with default state as SC 1`] = `
       name="state"
       onChange={[Function]}
       onFocus={[Function]}
-      placeholder="State/Territory"
-      value={undefined}>
+      placeholder="State/Territory">
       <option
         style={
           Object {
@@ -153,8 +150,7 @@ exports[`test renders with predefined state 1`] = `
       name="state"
       onChange={[Function]}
       onFocus={[Function]}
-      placeholder="State/Territory"
-      value={undefined}>
+      placeholder="State/Territory">
       <option
         style={
           Object {

--- a/imports/blocks/recover-schedules/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/recover-schedules/__tests__/__snapshots__/Layout.js.snap
@@ -105,8 +105,7 @@ exports[`Layout should render the Remind component if state is set to 'remind' 1
           name="frequency"
           onChange={[Function]}
           onFocus={[Function]}
-          placeholder={undefined}
-          value={undefined}>
+          placeholder={undefined}>
           <option
             className={undefined}
             value="tomorrow">

--- a/imports/components/forms/Select.js
+++ b/imports/components/forms/Select.js
@@ -186,9 +186,9 @@ export default class Select extends Component {
 
     // if a selected item is passed in, we don't need a defaultValue
     // conreolled/uncontrolled react error
-    const value = this.props.selected ? {value: this.props.selected || ""} : {};
+    const value = this.props.selected ? { value: this.props.selected || "" } : {};
     const defaultValue = this.props.defaultValue && !this.props.selected
-      ? {defaultValue: this.props.defaultValue || ""} : {};
+      ? { defaultValue: this.props.defaultValue || "" } : {};
 
     return (
       <div className={`${inputclasses.join(" ")} ${css(SelectClasses.select)}`}>

--- a/imports/components/forms/Select.js
+++ b/imports/components/forms/Select.js
@@ -183,6 +183,13 @@ export default class Select extends Component {
     if (this.props.classes) { inputclasses = inputclasses.concat(this.props.classes); }
 
     if (this.props.selected) { inputclasses.push("input--active"); }
+
+    // if a selected item is passed in, we don't need a defaultValue
+    // conreolled/uncontrolled react error
+    const value = this.props.selected ? {value: this.props.selected || ""} : {};
+    const defaultValue = this.props.defaultValue && !this.props.selected
+      ? {defaultValue: this.props.defaultValue || ""} : {};
+
     return (
       <div className={`${inputclasses.join(" ")} ${css(SelectClasses.select)}`}>
         {(() => {
@@ -210,9 +217,8 @@ export default class Select extends Component {
           disabled={this.disabled()}
           onFocus={this.focus}
           onChange={this.change}
-          defaultValue={this.props.defaultValue}
-          value={this.props.selected}
-
+          {...defaultValue}
+          {...value}
         >
           {(() => {
             if (this.props.placeholder || this.props.includeBlank) {

--- a/imports/components/forms/__tests__/__snapshots__/Select.js.snap
+++ b/imports/components/forms/__tests__/__snapshots__/Select.js.snap
@@ -6,13 +6,11 @@ exports[`test allows deselect 1`] = `
     labelName="myLabel" />
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="myLabel"
-    value={null}>
+    placeholder="myLabel">
     <option />
     <option
       className="one two"
@@ -36,13 +34,11 @@ exports[`test appends extra classes 1`] = `
     labelName="myLabel" />
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="myLabel"
-    value={null}>
+    placeholder="myLabel">
     <option
       className="one two"
       value="1">
@@ -62,13 +58,11 @@ exports[`test can hide the label 1`] = `
   className="input select_15p0e27">
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="myLabel"
-    value={null}>
+    placeholder="myLabel">
     <option
       className="one two"
       value="1">
@@ -91,13 +85,11 @@ exports[`test has active state 1`] = `
     labelName="myLabel" />
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="myLabel"
-    value={null}>
+    placeholder="myLabel">
     <option
       className="one two"
       value="1">
@@ -120,13 +112,11 @@ exports[`test has error state 1`] = `
     labelName="myLabel" />
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="myLabel"
-    value={null}>
+    placeholder="myLabel">
     <option
       className="one two"
       value="1">
@@ -149,13 +139,11 @@ exports[`test has focused state 1`] = `
     labelName="myLabel" />
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="myLabel"
-    value={null}>
+    placeholder="myLabel">
     <option
       className="one two"
       value="1">
@@ -178,13 +166,11 @@ exports[`test includes blank 1`] = `
     labelName="myLabel" />
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="myLabel"
-    value={null}>
+    placeholder="myLabel">
     <option
       style={
         Object {
@@ -213,13 +199,11 @@ exports[`test includes placeholder 1`] = `
     labelName="myLabel" />
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="myPlaceholder"
-    value={null}>
+    placeholder="myPlaceholder">
     <option
       style={
         Object {
@@ -250,7 +234,6 @@ exports[`test is active if selected prop 1`] = `
     labelName="myLabel" />
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
@@ -279,13 +262,11 @@ exports[`test overrides with theme if present 1`] = `
     labelName="myLabel" />
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="myLabel"
-    value={null}>
+    placeholder="myLabel">
     <option
       className="one two"
       value="1">
@@ -322,13 +303,11 @@ exports[`test renders with props 1`] = `
     labelName="myLabel" />
   <select
     className="input classes"
-    defaultValue={null}
     id="2"
     name="myName"
     onChange={[Function]}
     onFocus={[Function]}
-    placeholder="myLabel"
-    value={null}>
+    placeholder="myLabel">
     <option
       className="one two"
       value="1">

--- a/imports/pages/give/history/__tests__/Filter.js
+++ b/imports/pages/give/history/__tests__/Filter.js
@@ -341,15 +341,16 @@ it("onStartDayClick correctly sets state", () => {
     selected: true,
     disabled: false,
   }
+  const customDate = moment("2016-12-25");
 
-  wrapper.instance().onStartDayClick(null, "12/25/2016", selectedObject);
+  wrapper.instance().onStartDayClick(null, customDate, selectedObject);
   expect(wrapper.state().start).toEqual("");
   expect(wrapper.state().customStartLabel).toEqual("Start Date");
   expect(wrapper.state().customStartActive).toEqual(false);
 
   selectedObject.selected = false;
-  wrapper.instance().onStartDayClick(null, "12/25/2016", selectedObject);
-  expect(wrapper.state().start).toEqual("12/25/2016");
+  wrapper.instance().onStartDayClick(null, customDate, selectedObject);
+  expect(wrapper.state().start).toEqual(customDate);
   expect(wrapper.state().customStartLabel).toEqual("Dec 25, 2016");
   expect(wrapper.state().customStartActive).toEqual(true);
 })
@@ -365,15 +366,16 @@ it("onEndDayClick correctly sets state", () => {
     selected: true,
     disabled: false,
   }
+  const customDate = moment("2016-12-25");
 
-  wrapper.instance().onEndDayClick(null, "12/25/2016", selectedObject);
+  wrapper.instance().onEndDayClick(null, customDate, selectedObject);
   expect(wrapper.state().end).toEqual("");
   expect(wrapper.state().customEndLabel).toEqual("End Date");
   expect(wrapper.state().customEndActive).toEqual(false);
 
   selectedObject.selected = false;
-  wrapper.instance().onEndDayClick(null, "12/25/2016", selectedObject);
-  expect(wrapper.state().end).toEqual("12/25/2016");
+  wrapper.instance().onEndDayClick(null, customDate, selectedObject);
+  expect(wrapper.state().end).toEqual(customDate);
   expect(wrapper.state().customEndLabel).toEqual("Dec 25, 2016");
   expect(wrapper.state().customEndActive).toEqual(true);
 })
@@ -396,4 +398,3 @@ it("filterResults correctly calls all the functions", () => {
   wrapper.instance().filterResults();
   expect(mockFilterTransactions).toHaveBeenCalledWith({ people: [ "1", "2" ], start: "", end: "", limit: 20 });
 });
-

--- a/imports/pages/give/schedules/Details/Layout.js
+++ b/imports/pages/give/schedules/Details/Layout.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 // @flow
 import moment from "moment";
 import { Link } from "react-router";
@@ -283,3 +284,4 @@ export default ({
     </Left>
   </div>
 );
+/* eslint-enable react/no-danger */

--- a/imports/pages/home/index.js
+++ b/imports/pages/home/index.js
@@ -2,7 +2,6 @@ import { Component, PropTypes } from "react";
 import ReactMixin from "react-mixin";
 import { connect } from "react-redux";
 import { graphql } from "react-apollo";
-import { createFragment } from "apollo-client";
 import gql from "graphql-tag";
 
 import Split, { Left, Right } from "../../blocks/split";
@@ -123,18 +122,7 @@ class HomeWithoutData extends Component {
 
 }
 
-const CONTENT_FEED_QUERY = gql`
-  query getFeed($excludeChannels: [String]!, $limit: Int!, $skip: Int!, $cache: Boolean!) {
-    feed(excludeChannels: $excludeChannels, limit: $limit, skip: $skip, cache: $cache) {
-      ...ContentForFeed
-      parent {
-        ...ContentForFeed
-      }
-    }
-  }
-`;
-
-const contentFragment = createFragment(gql`
+const contentFragment = gql`
   fragment ContentForFeed on Content {
     entryId: id
     title
@@ -160,11 +148,22 @@ const contentFragment = createFragment(gql`
       }
     }
   }
-`);
+`;
+
+const CONTENT_FEED_QUERY = gql`
+  query getFeed($excludeChannels: [String]!, $limit: Int!, $skip: Int!, $cache: Boolean!) {
+    feed(excludeChannels: $excludeChannels, limit: $limit, skip: $skip, cache: $cache) {
+      ...ContentForFeed
+      parent {
+        ...ContentForFeed
+      }
+    }
+  }
+  ${contentFragment}
+`;
 
 const withFeedContent = graphql(CONTENT_FEED_QUERY, {
   options: (ownProps) => ({
-    fragments: [contentFragment],
     variables: {
       excludeChannels: ownProps.topics,
       limit: 20,

--- a/imports/pages/locations/Layout.js
+++ b/imports/pages/locations/Layout.js
@@ -92,7 +92,8 @@ export default class Layout extends Component {
         const element = this.slider;
         element.children[0].scrollIntoView({ block: "end", behavior: "smooth" });
         element.parentElement.scrollLeft += -20;
-      });
+      })
+      .catch((err) => console.error(err));
   }
 
   overflow = {

--- a/imports/pages/locations/Layout.js
+++ b/imports/pages/locations/Layout.js
@@ -93,7 +93,7 @@ export default class Layout extends Component {
         element.children[0].scrollIntoView({ block: "end", behavior: "smooth" });
         element.parentElement.scrollLeft += -20;
       })
-      .catch((err) => console.error(err));
+      .catch(() => { /* do nothing */ });
   }
 
   overflow = {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "cheerio": "^0.20.0",
     "compression": "^1.6.2",
     "cookie-parser": "^1.4.3",
+    "fibers": "^1.0.15",
     "google-map-react": "^0.14.8",
     "graphql-tag": "^0.1.8",
     "hammerjs": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3119,7 +3119,7 @@ fbjs@^0.8.1, fbjs@^0.8.3, fbjs@^0.8.4:
     promise "^7.1.1"
     ua-parser-js "^0.7.9"
 
-fibers@^1.0.4:
+fibers@^1.0.15, fibers@^1.0.4:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/fibers/-/fibers-1.0.15.tgz#22f039c8f18b856190fbbe4decf056154c1eae9c"
 


### PR DESCRIPTION
I started to cleanup some of the errors and warnings we're seeing on the CI logs.

I've fixed:
1. The `<Select>` tag had a `null` value prop, which is invalid
2. The `<Select>` tag had both a `value` and a `defaultValue` prop. If I understand controlled form components well enough, and how we have this built, if there's a `value`, there shouldn't be a `defaultValue` prop passed to select. I made sure only one of these two will ever show. *This passes tests but I'm not sure if it breaks anything else*
3. Apollo was complaining of using `createFragment` which is deprecated. I used the pattern [shown here](http://dev.apollodata.com/react/fragments.html) to fix this.
4. I updated the giving history filter tests to use moment objects when passing dates to functions instead of date strings, since that's what the component uses

## Tests

some snapshots previously had `{undefined}` or `{null}` in the `value` or `defaultValue` props for the select component. This is incorrect, and failed 20-something tests. _If only we had forms mocked for tests in other components_ ;) 