### PR TITLE
Converted Background Color Text Knob to Color Knob for Cards

### DIFF
--- a/imports/components/cards/__stories__/cards.FeedItem.js
+++ b/imports/components/cards/__stories__/cards.FeedItem.js
@@ -4,6 +4,7 @@ import {
   withKnobs,
   text,
   select,
+  color,
 } from "@kadira/storybook-addon-knobs";
 import withReadme from "storybook-readme/with-readme";
 import backgrounds from "react-storybook-addon-backgrounds";
@@ -65,7 +66,9 @@ story
 
     // Background Color For Series
     if (content.channelName === "series_newspring") {
-      content.content.colors[0].value = text("HEX Color", "303030");
+      const label = "Background Color";
+      const defaultValue = "#303030";
+      content.content.colors[0].value = color(label, defaultValue).replace('#','');
     }
 
     return (


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Converted Background Color Text Knob to Color Knob for Cards

# Testing/Documentation
- [X] All significant new logic is covered by tests.
- [X] Storybook documentation has been added.

# Screenshots
![image](https://cloud.githubusercontent.com/assets/2465823/21337769/2df0b6ac-c63e-11e6-961f-c8e54f6238e8.png)

# QA Process
All new features and fixes should be tested and signed off on in the [device testing document](https://docs.google.com/spreadsheets/d/1TG0jmltkp61oRA4nYpcoGFTh1lDxa1A8dSnitBKT0lk/edit#gid=1270385294) that corresponds to this PR. **This PR should be tested and PASS on all devices/breakpoints prior to merging.**

# Reporting Bugs
If you find an issue, a bug, or something that seems weird, thank you! That is extremely helpful. You can report this kind of feedback using our [GitHub Issues page](https://github.com/NewSpring/Holtzman/issues). Here are a few things that are great to include in an issue:

- Reference to this pull request.
- Steps to reproduce the issue
- Explanation of the buggy behavior
- Explanation of the expected behavior
- Screenshots of the app if helpful

Here is a link to a [good example issue.](https://github.com/NewSpring/Apollos/issues/841)