### PR TITLE
Added contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,9 @@ the same reason.
 add a react storybook test. These are found in `__stories__` subfolders.
 4. Ensure tests pass on Travis and Circle CI. These automatically run when opening a
 pull request.
-7. Make sure your code lints (`npm run lint`).
-8. Make sure your code is typed using flow (`npm run flow`).
-9. Rebase your code to master (`git rebase`). Stating one-line intentions along
+5. Make sure your code lints (`npm run lint`).
+6. Make sure your code is typed using flow (`npm run flow`).
+7. Rebase your code to master (`git rebase`). Stating one-line intentions along
 with each commit helps the reviewer to understand what you're changing.
 
 ## Bugs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to Holtzman
+
+Holtzman is NewSpring's open sourced project to build apps for  web, iOS, and Android.
+This project is under heavy active development, and it currently being used in production
+for [my.newspring.cc](https://my.newspring.cc) and [our current apps](https://newspring.cc/apps).
+We're currently in the process of making this project easy to contribute to.
+Hopefully, this document sheds some light into our processes, and how you can contribute.
+
+## Our Development Process
+
+Our team works 100% off of Github, and it should always remain updated with what is currently
+in active development.
+
+### `master` is unsafe
+
+Our team works off of individual feature branches which eventually get merged into
+`master` before being deployed. Since this is the case, the `master` branch may at
+some times contain bugs or API changes that haven't been fully communicated or tested,
+and may break older versions of the app.
+
+We will do our best to keep `master` in working order, with all tests passing. For
+a stable release of the app, you can always explore our past and current [releases](https://github.com/NewSpring/Holtzman/releases)
+
+### Pull Requests
+
+We work off of pull requests pretty heavily, and therefore we monitor for new PR's.
+When considering pull requests, we may require more than one person to sign off,
+so these can sometimes take a day or two.
+
+When working to fix bugs or add features, we recommend opening a pull request early
+so we can comment on it or request any changes early on. It is also recommended that
+you work off of open issues, and let us know on them what you will be working on for
+the same reason.
+
+**Please submit your pull request on the `master` branch**.
+
+*Before* submitting a pull request, please make sure the following is done…
+
+1. Fork the repo and create your branch from `master`.
+2. **Describe your test plan in your commit.** If you've added code that should be tested, add tests in `__tests__` subfolders
+3. If the changes you are making are visual or involve new components, please also
+add a react storybook test. These are found in `__stories__` subfolders.
+4. Ensure tests pass on Travis and Circle CI. These automatically run when opening a
+pull request.
+7. Make sure your code lints (`npm run lint`).
+8. Make sure your code is typed using flow (`npm run flow`).
+9. Rebase your code to master (`git rebase`). Stating one-line intentions along
+with each commit helps the reviewer to understand what you're changing.
+
+## Bugs
+
+### Where to Find Known Issues
+
+We are using [GitHub Issues](https://github.com/NewSpring/holtman/issues)
+for our public bugs. We keep a close eye on this and try to make it clear when
+we have an internal fix in progress. Before filing a new task, try to make sure
+your problem doesn't already exist.
+
+### Reporting New Issues
+
+The best way to get a bug fixed is to provide an example case of where the problem
+is occurring. Images or videos of the failure occurring is beneficial where
+applicable. If you think you have a solution to a bug and would like to fix it,
+let us know. We can hopefully provide recommendations, as well as let you know
+if the bug is in fact intended behavior.
+
+### Recommending New Features
+
+We also track feature requests using Github Issues. If you would like to begin
+a discussion about a new or improved feature, open a new issue.
+
+## How to Get in Touch
+
+* [Twitter](https://twitter.com/newspringweb)
+
+## Style Guide
+
+### Code
+
+#### General
+
+* **Most important: Look around.** Match the style you see used in the rest of the project. This includes formatting, naming things in code, naming things in documentation.
+* Add trailing commas,
+* 2 spaces for indentation (no tabs)
+* "Attractive"
+
+#### JavaScript
+
+* Use semicolons;
+* Prefer `"` over `'`
+* 100 character line length
+
+#### JSX
+
+* Prefer `"` over `'` for string literal props
+* When wrapping opening tags over multiple lines, place one prop per line
+* `{}` of props should hug their values (no spaces)
+* Place the closing `>` of opening tags on the same line as the last prop
+* Place the closing `/>` of self-closing tags on their own line and left-align them with the opening `<`
+
+## License
+
+By contributing to Holtzman, you agree that your contributions will be licensed under its MIT license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,18 +9,18 @@ Hopefully, this document sheds some light into our processes, and how you can co
 **Table of Contents**
 
 [How we work](#how-we-work)
-- [master is unsafe](#master-is-unsafe)
-- [Pull Requests](#pull-requests)
+  * [master is unsafe](#master-is-unsafe)
+  * [Pull Requests](#pull-requests)
 
 [How can I contribute?](#how-can-i-contribute)
-- [Where to find known issues](#where-to-find-known-issues)
-- [Reporting new issues](#reporting-new-issues)
-- [How can I recommend new features](#how-can-i-recommend-new-features)
-- [Pull requests](#pull-requests)
+  * [Where to find known issues](#where-to-find-known-issues)
+  * [Reporting new issues](#reporting-new-issues)
+  * [How can I recommend new features](#how-can-i-recommend-new-features)
+  * [Pull requests](#pull-requests)
 
 [Style Guide](#style-guide)
-- [Git](#git)
-- [Code](#code)
+  * [Git](#git)
+  * [Code](#code)
 
 [How to get in touch](#how-to-get-in-touch)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Holtzman
 
-Holtzman is NewSpring's open sourced project to build apps for  web, iOS, and Android.
+Holtzman is NewSpring's open sourced project to build apps for web, iOS, and Android.
 This project is under heavy active development, and it currently being used in production
 for [my.newspring.cc](https://my.newspring.cc) and [our current apps](https://newspring.cc/apps).
 We're currently in the process of making this project easy to contribute to.
@@ -40,10 +40,10 @@ the same reason.
 2. **Describe your test plan in your commit.** If you've added code that should be tested, add tests in `__tests__` subfolders
 3. If the changes you are making are visual or involve new components, please also
 add a react storybook test. These are found in `__stories__` subfolders.
-4. Ensure tests pass on Travis and Circle CI. These automatically run when opening a
+4. Ensure tests pass on Travis and Coveralls. These automatically run when opening a
 pull request.
-5. Make sure your code lints (`npm run lint`).
-6. Make sure your code is typed using flow (`npm run flow`).
+5. Make sure your code lints (`yarn lint`).
+6. Make sure your code is typed using flow (`yarn flow`).
 7. Rebase your code to master (`git rebase`). Stating one-line intentions along
 with each commit helps the reviewer to understand what you're changing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,27 @@ for [my.newspring.cc](https://my.newspring.cc) and [our current apps](https://ne
 We're currently in the process of making this project easy to contribute to.
 Hopefully, this document sheds some light into our processes, and how you can contribute.
 
-## Our Development Process
+**Table of Contents**
+
+[How we work](#how-we-work)
+- [master is unsafe](#master-is-unsafe)
+- [Pull Requests](#pull-requests)
+
+[How can I contribute?](#how-can-i-contribute)
+- [Where to find known issues](#where-to-find-known-issues)
+- [Reporting new issues](#reporting-new-issues)
+- [How can I recommend new features](#how-can-i-recommend-new-features)
+- [Pull requests](#pull-requests)
+
+[Style Guide](#style-guide)
+- [Git](#git)
+- [Code](#code)
+
+[How to get in touch](#how-to-get-in-touch)
+
+[License](#license)
+
+## How we work
 
 Our team works 100% off of Github, and it should always remain updated with what is currently
 in active development.
@@ -26,6 +46,32 @@ a stable release of the app, you can always explore our past and current [releas
 We work off of pull requests pretty heavily, and therefore we monitor for new PR's.
 When considering pull requests, we may require more than one person to sign off,
 so these can sometimes take a day or two.
+
+## How can I contribute?
+
+One way you can contribute is by tackling some known issues.
+
+### Where to Find Known Issues
+
+We are using [GitHub Issues](https://github.com/NewSpring/holtman/issues)
+for our public bugs. We keep a close eye on this and try to make it clear when
+we have an internal fix in progress. Before filing a new task, try to make sure
+your problem doesn't already exist.
+
+### Reporting New Issues
+
+The best way to get a bug fixed is to provide an example case of where the problem
+is occurring. Images or videos of the failure occurring is beneficial where
+applicable. If you think you have a solution to a bug and would like to fix it,
+let us know. We can hopefully provide recommendations, as well as let you know
+if the bug is in fact intended behavior.
+
+### How can I recommend new features?
+
+We track feature requests using Github Issues. If you would like to begin
+a discussion about a new or improved feature, open a new issue.
+
+### Pull requests
 
 When working to fix bugs or add features, we recommend opening a pull request early
 so we can comment on it or request any changes early on. It is also recommended that
@@ -47,33 +93,22 @@ pull request.
 7. Rebase your code to master (`git rebase`). Stating one-line intentions along
 with each commit helps the reviewer to understand what you're changing.
 
-## Bugs
-
-### Where to Find Known Issues
-
-We are using [GitHub Issues](https://github.com/NewSpring/holtman/issues)
-for our public bugs. We keep a close eye on this and try to make it clear when
-we have an internal fix in progress. Before filing a new task, try to make sure
-your problem doesn't already exist.
-
-### Reporting New Issues
-
-The best way to get a bug fixed is to provide an example case of where the problem
-is occurring. Images or videos of the failure occurring is beneficial where
-applicable. If you think you have a solution to a bug and would like to fix it,
-let us know. We can hopefully provide recommendations, as well as let you know
-if the bug is in fact intended behavior.
-
-### Recommending New Features
-
-We also track feature requests using Github Issues. If you would like to begin
-a discussion about a new or improved feature, open a new issue.
-
-## How to Get in Touch
-
-* [Twitter](https://twitter.com/newspringweb)
-
 ## Style Guide
+
+### Git
+
+#### Issues
+- Above all, pay attention to the template shown when creating issues.
+- Before opening an issue, search existing issues and closed issues for any current or past discussion about your topic.
+
+#### Commits and commit messages
+- Try to limit each commit to one change.
+- Commits messages should be short and clear.
+- Feel free to reference issues and pull requests in commit messages.
+
+#### Pull Requests
+- Refer to the [above instructions](#pull-requests) on what to do before opening a pull request.
+- Follow instructions on the pull request template shown when opening a new pull request.
 
 ### Code
 
@@ -97,6 +132,11 @@ a discussion about a new or improved feature, open a new issue.
 * `{}` of props should hug their values (no spaces)
 * Place the closing `>` of opening tags on the same line as the last prop
 * Place the closing `/>` of self-closing tags on their own line and left-align them with the opening `<`
+
+
+## How to Get in Touch
+
+* [Twitter](https://twitter.com/newspringweb)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To install all dependencies, we use [Yarn](https://yarnpkg.com/). To get started
 1. Clone down the repo
 2. Make sure you have the Yarn CLI [installed](https://yarnpkg.com/en/docs/install)
 3. Run `yarn`.
-4. run `npm link`. This will bind `apollos` to your system to be used to run this app.
+4. run `npm link`. This will bind `apollos` to your system to be used to run this app ([more info](https://docs.npmjs.com/cli/link)).
 
 `apollos setup`: This command will bootstrap the application. This may take some time.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ Church](https://img.shields.io/badge/NEWSPRING_CHURCH-Holtzmann-6BAC43.svg?style
 
 Holtzmann is a reactive application framework for building high speed, web + native, reactive applications. It is built using Reactjs, Redux, and Meteor. This repository contains the application framework and instructions for usage.
 
+**Table of Contents**
+
+[Prerequisites](#prerequisites)
+
+[Quick Start](#quick-start)
+
+[Structure](#structure)
+
+[Local Development](#local-development)
+  * [Testing](#testing)
+  * [Linting](#linting)
+  * [Typing](#typing)
+
+[Deploys](#deploys)
+
+[Contributing](#contributing)
+
 ## Prerequisites
 
 - [Meteor](curl https://install.meteor.com/ | sh): `curl https://install.meteor.com/ | sh`;
@@ -43,6 +60,8 @@ This repo contains the code base used to build v5 of the NewSpring site and nati
 
 ## Local Development
 
+### Basics
+
 To install all dependencies, we use [Yarn](https://yarnpkg.com/). To get started:
 1. Clone down the repo
 2. Make sure you have the Yarn CLI [installed](https://yarnpkg.com/en/docs/install)
@@ -66,13 +85,13 @@ To install all dependencies, we use [Yarn](https://yarnpkg.com/). To get started
   - `--production`: Run the application in production mode
   - `--debug`: Run the application in debug mode
 
-## Testing
+### Testing
 
 This project uses [Jest](https://facebook.github.io/jest/) for unit tests. These tests are located in `__tests__` subfolders adjacent to the thing they're testing.
 
 To run tests, call `yarn test` or `yarn test -- --watch`. This will also run `eslint` and `flow` tests when complete.
 
-## Linting
+### Linting
 
 This project includes linting using [ESLint](http://eslint.org/).  To enable linting in Visual Studio Code, you will need to install the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
 
@@ -84,7 +103,7 @@ ext install vscode-eslint
 
 To manually run eslint, use `yarn lint`.
 
-## Typing
+### Typing
 
 This project contains static typing for most code. We use [Flow](https://flowtype.org/) for this. To enable flow to a file,
 add `// @flow` to the very top of the file.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ This repo contains the code base used to build v5 of the NewSpring site and nati
 - `/scripts`: command line scripts used for deployment, testing, etc
 - `/server`: entry point for server
 - `/stylesheets`: sass for generating our css using sass and junction
+- `*/__tests__`: tests adjacent to the module they are testing
+- `*/__stories__`: react storybook stories adjacent to the module they are displaying
+- `*/__mocks__`: module mocks for testing adjacent to the module they mock.
 - `main.html`: root HTML file
 - `mobile-config.js`: used to generate cordova apps
 - `package.json`: used to manage npm dependencies and etc.
@@ -58,6 +61,12 @@ To install, clone down this repo and run `npm link`. This will bind `apollos` to
   - `--production`: Run the application in production mode
   - `--debug`: Run the application in debug mode
 
+## Testing
+
+This project uses [Jest](https://facebook.github.io/jest/) for unit tests. These tests are located in `__tests__` subfolders adjacent to the thing they're testing.
+
+To run tests, call `npm test` or `npm test -- --watch`. This will also run `eslint` and `flow` tests when complete.
+
 ## Linting
 
 This project includes linting using [ESLint](http://eslint.org/).  To enable linting in Visual Studio Code, you will need to install the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
@@ -67,6 +76,15 @@ To install the extension you'll need to press `⌘+P`, paste the following comma
 ```
 ext install vscode-eslint
 ```
+
+To manually run eslint, use `npm run lint`.
+
+## Typing
+
+This project contains static typing for most code. We use [Flow](https://flowtype.org/) for this. To enable flow to a file,
+add `// @flow` to the very top of the file.
+
+To run flow, use `npm run flow`.
 
 ## Deploys
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,16 @@ This repo contains the code base used to build v5 of the NewSpring site and nati
 - `*/__mocks__`: module mocks for testing adjacent to the module they mock.
 - `main.html`: root HTML file
 - `mobile-config.js`: used to generate cordova apps
-- `package.json`: used to manage npm dependencies and etc.
+- `package.json`: used to manage yarn dependencies and etc.
+- `yarn.lock`: used to make sure all developers are using the same package versions
 
 ## Local Development
 
-To install, clone down this repo and run `npm link`. This will bind `apollos` to your system to be used to run this app.
+To install all dependencies, we use [Yarn](https://yarnpkg.com/). To get started:
+1. Clone down the repo
+2. Make sure you have the Yarn CLI [installed](https://yarnpkg.com/en/docs/install)
+3. Run `yarn`.
+4. run `npm link`. This will bind `apollos` to your system to be used to run this app.
 
 `apollos setup`: This command will bootstrap the application. This may take some time.
 
@@ -65,7 +70,7 @@ To install, clone down this repo and run `npm link`. This will bind `apollos` to
 
 This project uses [Jest](https://facebook.github.io/jest/) for unit tests. These tests are located in `__tests__` subfolders adjacent to the thing they're testing.
 
-To run tests, call `npm test` or `npm test -- --watch`. This will also run `eslint` and `flow` tests when complete.
+To run tests, call `yarn test` or `yarn test -- --watch`. This will also run `eslint` and `flow` tests when complete.
 
 ## Linting
 
@@ -77,14 +82,14 @@ To install the extension you'll need to press `⌘+P`, paste the following comma
 ext install vscode-eslint
 ```
 
-To manually run eslint, use `npm run lint`.
+To manually run eslint, use `yarn lint`.
 
 ## Typing
 
 This project contains static typing for most code. We use [Flow](https://flowtype.org/) for this. To enable flow to a file,
 add `// @flow` to the very top of the file.
 
-To run flow, use `npm run flow`.
+To run flow, use `yarn flow`.
 
 ## Deploys
 

--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ To deploy, create a release/tag using a combination of the site name, site versi
 newspring/web/production/1.0.8
 newspring/native/beta/0.0.3-45
 ```
+
+## Contributing
+
+For more information about contributing PRs and issues, see our [Contribution Guidelines](https://github.com/NewSpring/Holtzman/blob/master/CONTRIBUTING.md).
+
+[Good First PR](https://github.com/NewSpring/Holtzman/labels/good first pr) is a great starting point for people new to this project.


### PR DESCRIPTION
I added a contribution document to make clear exactly how people can begin contributing to Holtzman. I largely based it off of [React Native's Contribution Guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md).

I think explaining specifics to structure, how storybook tests work, etc would be good to link to in this eventually once we write a post about it.