### PR TITLE
Fix history filter buttons

### DIFF
--- a/imports/pages/give/history/Filter.js
+++ b/imports/pages/give/history/Filter.js
@@ -151,7 +151,6 @@ export default class Filter extends Component {
 
         return {
           showStartDatePicker: !showStartDatePicker,
-          overrideActive: true,
         };
       });
     }
@@ -173,7 +172,6 @@ export default class Filter extends Component {
 
         return {
           showEndDatePicker: !showEndDatePicker,
-          overrideActive: true,
         };
       });
     }
@@ -185,6 +183,7 @@ export default class Filter extends Component {
       start: selected ? "" : day,
       customStartLabel: selected ? "Start Date" : moment(day).format("ll"),
       customStartActive: !selected,
+      overrideActive: !selected,
     });
   }
 
@@ -194,6 +193,7 @@ export default class Filter extends Component {
       end: selected ? "" : day,
       customEndLabel: selected ? "End Date" : moment(day).format("ll"),
       customEndActive: !selected,
+      overrideActive: !selected,
     });
   }
 

--- a/imports/pages/give/history/Filter.js
+++ b/imports/pages/give/history/Filter.js
@@ -301,7 +301,6 @@ export default class Filter extends Component {
                     this.state.customStartActive
                   )}
                   className={(
-                    this.state.customStartLabel !== "Start Date" &&
                     this.state.customDateDisabled &&
                     "tag--disabled"
                   )}
@@ -322,7 +321,6 @@ export default class Filter extends Component {
                     this.state.customEndActive
                   )}
                   className={(
-                    this.state.customEndLabel !== "End Date" &&
                     this.state.customDateDisabled &&
                     "tag--disabled"
                   )}

--- a/imports/pages/give/history/__tests__/Filter.js
+++ b/imports/pages/give/history/__tests__/Filter.js
@@ -270,18 +270,16 @@ it("toggleEndDatePicker correctly toggles the end date picker", () => {
   expect(wrapper.state().showEndDatePicker).toEqual(false);
 })
 
-it("startClick with StartDate value and blank start date shows the start date picker and overrides date range buttons", () => {
+it("startClick with StartDate value and blank start date shows the start date picker", () => {
   const wrapper = shallow(generateComponent());
   wrapper.setState({
     showStartDatePicker: false,
-    overrideActive: false,
     start: "",
   });
 
   // calling it should toggle the picker on and set the override to true.
   wrapper.instance().startClick("StartDate");
   expect(wrapper.state().showStartDatePicker).toEqual(true);
-  expect(wrapper.state().overrideActive).toEqual(true);
 })
 
 it("startClick with StartDate value and non-empty start date resets many things", () => {
@@ -300,18 +298,16 @@ it("startClick with StartDate value and non-empty start date resets many things"
   expect(wrapper.state().overrideActive).toEqual(false);
 })
 
-it("startClick with EndDate value and blank end date shows the end date picker and overrides date range buttons", () => {
+it("startClick with EndDate value and blank end date shows the end date picker", () => {
   const wrapper = shallow(generateComponent());
   wrapper.setState({
     showEndDatePicker: false,
-    overrideActive: false,
     end: ""
   });
 
   // calling it should toggle the picker on and set the override to true.
   wrapper.instance().startClick("EndDate");
   expect(wrapper.state().showEndDatePicker).toEqual(true);
-  expect(wrapper.state().overrideActive).toEqual(true);
 })
 
 it("startClick with EndDate value and non-empty start date resets many things", () => {


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Fix for custom start date buttons not being disabled when a date range button was clicked.
- Fix so that the date range buttons only get disabled when a date is actually selected from the custom date picker.