### PR TITLE
Fix SVG scaling on Safari

### DIFF
--- a/imports/components/graphs/lineGraph/index.js
+++ b/imports/components/graphs/lineGraph/index.js
@@ -51,11 +51,11 @@ class LineGraph extends Component {
   props: ILineGraph;
 
   componentDidMount() {
-    const renderedChart = this.graphContainer.querySelectorAll('[aria-labelledby="title desc"]')[0];
-    renderedChart.removeAttribute("height");
+    const renderedChart = this.graphContainer.querySelectorAll("[aria-labelledby='title desc']");
+    if (renderedChart && renderedChart.length) renderedChart[0].removeAttribute("height");
   }
 
-  render(){
+  render() {
     const {
       axisStyles,
       data,
@@ -64,10 +64,10 @@ class LineGraph extends Component {
       lineColor,
       lineWidth,
     } = this.props;
-    return(
+    return (
       <div
         className=""
-        ref={(el) => this.graphContainer = el}
+        ref={(el) => (this.graphContainer = el)}
       >
         <VictoryChart
           height={160}

--- a/imports/components/graphs/lineGraph/index.js
+++ b/imports/components/graphs/lineGraph/index.js
@@ -6,6 +6,7 @@ import {
   VictoryScatter,
   VictoryArea,
 } from "victory";
+import React, { Component } from "react";
 
 type ILineGraph = {
   axisStyles: Object,
@@ -46,62 +47,77 @@ const GradientGroup = ({ style, events, transform, children, gradientColor }: IG
   </g>
 );
 
-const LineGraph = ({
-  axisStyles,
-  data,
-  dotColor,
-  dotSize,
-  lineColor,
-  lineWidth,
-}: ILineGraph) => (
-  <div className="">
-    <VictoryChart
-      height={160}
-      padding={{ top: 5, left: 10, right: 10, bottom: 20 }}
-      animate={{ duration: 2000 }}
-    >
-      <VictoryAxis
-        style={{
-          axis: {
-            stroke: `${axisStyles.axis.lineColor}`,
-            strokeWidth: `${axisStyles.axis.lineWidth}`,
-          },
-          tickLabels: {
-            fontFamily: "colfax-web, sans-serif",
-            fontSize: `${axisStyles.tickLabels.fontSize}`,
-            fill: `${axisStyles.tickLabels.fill}`,
-          },
-        }}
-        tickFormat={getTickFormat(data)}
-      />
-      <VictoryArea
-        data={data}
-        x="month"
-        y="amount"
-        groupComponent={<GradientGroup gradientColor={lineColor} />}
-        style={{
-          data: { fill: "url(#gradient)", stroke: "none", opacity: 0.5 },
-        }}
-      />
-      <VictoryLine
-        data={data}
-        x="month"
-        y="amount"
-        style={{
-          data: { stroke: `${lineColor}`, strokeWidth: `${lineWidth}` },
-        }}
-      />
-      <VictoryScatter
-        data={data}
-        x="month"
-        y="amount"
-        size={dotSize}
-        style={{
-          data: { fill: dotColor },
-        }}
-      />
-    </VictoryChart>
-  </div>
-);
+class LineGraph extends Component {
+  props: ILineGraph;
+
+  componentDidMount() {
+    const renderedChart = this.graphContainer.querySelectorAll('[aria-labelledby="title desc"]')[0];
+    renderedChart.removeAttribute("height");
+  }
+
+  render(){
+    const {
+      axisStyles,
+      data,
+      dotColor,
+      dotSize,
+      lineColor,
+      lineWidth,
+    } = this.props;
+    return(
+      <div
+        className=""
+        ref={(el) => this.graphContainer = el}
+      >
+        <VictoryChart
+          height={160}
+          padding={{ top: 5, left: 10, right: 10, bottom: 20 }}
+          animate={{ duration: 2000 }}
+        >
+          <VictoryAxis
+            style={{
+              axis: {
+                stroke: `${axisStyles.axis.lineColor}`,
+                strokeWidth: `${axisStyles.axis.lineWidth}`,
+              },
+              tickLabels: {
+                fontFamily: "colfax-web, sans-serif",
+                fontSize: `${axisStyles.tickLabels.fontSize}`,
+                fill: `${axisStyles.tickLabels.fill}`,
+              },
+            }}
+            tickFormat={getTickFormat(data)}
+          />
+          <VictoryArea
+            data={data}
+            x="month"
+            y="amount"
+            groupComponent={<GradientGroup gradientColor={lineColor} />}
+            style={{
+              data: { fill: "url(#gradient)", stroke: "none", opacity: 0.5 },
+            }}
+          />
+          <VictoryLine
+            data={data}
+            x="month"
+            y="amount"
+            style={{
+              data: { stroke: `${lineColor}`, strokeWidth: `${lineWidth}` },
+            }}
+          />
+          <VictoryScatter
+            data={data}
+            x="month"
+            y="amount"
+            size={dotSize}
+            style={{
+              data: { fill: dotColor },
+            }}
+          />
+        </VictoryChart>
+      </div>
+    );
+  }
+}
 
 export default LineGraph;


### PR DESCRIPTION
# Feature / Fixed Issue(s)
Chart SVG on safari would scale down in size, but never up. It is taking the `height` attribute on the `<svg>` element instead of the `style` override. 

Proof: 
![screen shot 2016-12-20 at 1 22 24 pm](https://cloud.githubusercontent.com/assets/9259509/21362681/7cbfa79c-c6b7-11e6-8aaf-4c2d934b17cb.png)

Chrome is still working too: 
![screen shot 2016-12-20 at 1 23 50 pm](https://cloud.githubusercontent.com/assets/9259509/21362714/91c68ed0-c6b7-11e6-8c69-2cb7b11d161b.png)