### PR TITLE
Fix select

### DIFF
--- a/imports/blocks/give/__tests__/Layout.js
+++ b/imports/blocks/give/__tests__/Layout.js
@@ -56,9 +56,11 @@ it("renders Billing form", () => {
         personal: {},
         billing: {},
       },
-      state: "default",
+      state: "SC",
       step: 2,
     },
+    states: ["SC","NC"],
+    countries: ["USA","Others"],
   }));
   expect(result).toMatchSnapshot();
 });

--- a/imports/blocks/give/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/blocks/give/__tests__/__snapshots__/Layout.js.snap
@@ -75,7 +75,12 @@ exports[`test renders Billing form 1`] = `
         defaultValue="US"
         errorText="Please enter your country"
         includeBlank={true}
-        items={Array []}
+        items={
+          Array [
+            "USA",
+            "Others",
+          ]
+        }
         label="Country"
         name="country"
         validation={[Function]} />
@@ -93,7 +98,12 @@ exports[`test renders Billing form 1`] = `
             defaultValue="SC"
             errorText="Please enter your state"
             includeBlank={true}
-            items={Array []}
+            items={
+              Array [
+                "SC",
+                "NC",
+              ]
+            }
             label="State/Territory"
             name="state"
             validation={[Function]} />

--- a/imports/blocks/give/fieldsets/billing/Layout.js
+++ b/imports/blocks/give/fieldsets/billing/Layout.js
@@ -104,7 +104,7 @@ const Layout = ({
         defaultValue={billing.streetAddress2}
       />
 
-      <Forms.Select
+      {countries && countries.length && <Forms.Select
         name="country"
         label="Country"
         errorText="Please enter your country"
@@ -112,7 +112,7 @@ const Layout = ({
         items={countries}
         validation={saveCountry}
         includeBlank
-      />
+      />}
 
       <Forms.Input
         name="city"
@@ -123,11 +123,11 @@ const Layout = ({
       />
 
       <div className="grid">
-        <StateOrTerritory
+        {states && states.length && <StateOrTerritory
           billing={billing}
           states={states}
           saveState={saveState}
-        />
+        />}
         <Zip
           billing={billing}
           zip={zip}


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- resolves #1632 
- Fixes where select dropdowns in the billing window where the defaultValue wasn't being used when the options were loaded late.
- I added a check on the parent to not render select unless data is already present
