### PR TITLE
Make the select arrow white

### DIFF
--- a/imports/pages/give/home/RightPanel.js
+++ b/imports/pages/give/home/RightPanel.js
@@ -37,7 +37,7 @@ export default withData(({ loading, data, changeYear }) => (
               See your summary from
           </em></small>
         </p>
-        <style>{".right-select select { color: #ffffff }"}</style>
+        <style>{".right-select select { color: #ffffff } .right-select:after {border-color: #ffffff transparent transparent}"}</style>
         <Forms.Select
           items={YEARS}
           hideLabel


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Fix the select arrow on the right panel to be white. Like snow at Christmas. Not that we have any of that. 