### PR TITLE
Fix activity feed not showing all contributions

### DIFF
--- a/imports/components/cards/__tests__/__snapshots__/cards.Activity.js.snap
+++ b/imports/components/cards/__tests__/__snapshots__/cards.Activity.js.snap
@@ -1,3 +1,41 @@
+exports[`Activity should accept a react component as message prop 1`] = `
+<div
+  className="card">
+  <div
+    className="card__item soft text-left soft-bottom rounded background--light-primary text-dark">
+    <div
+      className="floating text-left">
+      <i
+        className="soft-half-right">
+        <Success
+          fill="#6bac43"
+          height="31px"
+          width="30px" />
+      </i>
+      <h5
+        className="text-dark-tertiary display-inline-block floating__item soft-half-bottom">
+        Dec 25, 2016
+      </h5>
+    </div>
+    <p>
+      hello world
+    </p>
+    <Link
+      className="text-primary plain"
+      onlyActiveOnIndex={false}
+      style={Object {}}
+      to="https://my.newspring.cc/give/now">
+      <h5
+        className="display-inline-block flush-bottom">
+        Click This Link
+      </h5>
+      <span
+        className="icon-arrow-next soft-half-left" />
+    </Link>
+  </div>
+</div>
+`;
+
 exports[`Activity should render the failed status component 1`] = `
 <div
   className="card">

--- a/imports/components/cards/__tests__/cards.Activity.js
+++ b/imports/components/cards/__tests__/cards.Activity.js
@@ -24,6 +24,12 @@ describe("Activity", () => {
     expect(shallowToJson(component)).toMatchSnapshot();
   });
 
+  it("should accept a react component as message prop", () => {
+    const message = <p>hello world</p>
+    const component = shallow(generateComponent({message: message}));
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
   it("should render the warning status component", () => {
     const component = shallow(generateComponent({ status: "warning" }));
     expect(shallowToJson(component)).toMatchSnapshot();

--- a/imports/components/cards/cards.Activity.js
+++ b/imports/components/cards/cards.Activity.js
@@ -56,7 +56,7 @@ const Activity = ({
         <i className="soft-half-right">{getIcon(status)}</i>
         {date && <h5 className={`${status === "success" ? "text-dark-tertiary " : ""}display-inline-block floating__item soft-half-bottom`}>{ moment(date).format("MMM D, YYYY") }</h5>}
       </div>
-      <p>{message}</p>
+      {typeof message === "string" ? <p>{message}</p> : message}
       {linkText && linkUrl && (
         <Link
           to={linkUrl}

--- a/imports/components/cards/cards.Activity.js
+++ b/imports/components/cards/cards.Activity.js
@@ -38,7 +38,7 @@ const getIcon = (status: string) => {
 type IActivity = {
   status: string,
   date: ?string,
-  message: string,
+  message: any,
   linkText: ?string,
   linkUrl: ?string,
 };

--- a/imports/pages/give/home/Activity.js
+++ b/imports/pages/give/home/Activity.js
@@ -36,7 +36,13 @@ export class GivingActivity extends Component {
     // separate feed by transactions and accoutns
     data.forEach((feedItem: Object) => {
       if (typeof feedItem.status !== "undefined") {
-        transactions.push(feedItem);
+        // there can be more than one account per transaction.
+        // separate these into separate activity cards
+        feedItem.details.map((detailItem) => {
+          const singleActivity = JSON.parse(JSON.stringify(feedItem));
+          singleActivity.details = [detailItem];
+          transactions.push(singleActivity);
+        });
       }
       // else {
       //   accounts.push(feedItem);
@@ -94,7 +100,7 @@ export class GivingActivity extends Component {
 
     return (
       <ActivityCard
-        key={transaction.id}
+        key={`${transaction.id.slice(0,-8)}_${transaction.details[0].account.name}`}
         status={status}
         date={transaction.date}
         message={message}
@@ -175,4 +181,3 @@ export class GivingActivity extends Component {
 }
 
 export default GivingActivity;
-

--- a/imports/pages/give/home/Activity.js
+++ b/imports/pages/give/home/Activity.js
@@ -62,8 +62,8 @@ export class GivingActivity extends Component {
     return activityToShow;
   };
 
-  additionalAmount = (details) => {
-    const amount = details.amount === parseInt(details.amount)
+  additionalAmount = (details: Object) => {
+    const amount = details.amount === parseInt(details.amount, 10)
       ? details.amount
       : details.amount.toFixed(2);
 
@@ -81,7 +81,7 @@ export class GivingActivity extends Component {
     const scheduled = transaction.schedule !== null;
 
     // show .00 on whole-dollar amounts. Don't show on even dollars
-    const amount = transaction.details[0].amount === parseInt(transaction.details[0].amount)
+    const amount = transaction.details[0].amount === parseInt(transaction.details[0].amount, 10)
       ? transaction.details[0].amount
       : transaction.details[0].amount.toFixed(2);
 
@@ -89,33 +89,45 @@ export class GivingActivity extends Component {
       status = "success";
       linkText = "View Gift";
       linkUrl = `/give/history/${transaction.id}`;
-      message = <p>
-        Your {scheduled ? "scheduled " : ""}gift of <strong>${amount} </strong>
-        to <strong>{transaction.details[0].account.name} </strong>
-        {transaction.details.length > 1 ? this.additionalAmount(transaction.details[1]) : null} was successful.
-      </p>;
+      message = (
+        <p>
+          Your {scheduled ? "scheduled " : ""}gift of <strong>${amount} </strong>
+          to <strong>{transaction.details[0].account.name} </strong>
+          {transaction.details.length > 1 ? this.additionalAmount(transaction.details[1]) : null}
+          was successful.
+        </p>
+      );
     } else if (transaction.status === "Failed") {
       status = "failed";
-      message = <p>
-        Your {scheduled ? "scheduled " : ""}contribution to
-        <strong> {transaction.details[0].account.name} </strong>
-        {transaction.details.length > 1 ? <span>and<strong> {account.details[1].name} </strong></span> : null}
-        was unsuccessful.
-        {transaction.statusMessage !== null && transaction.statusMessage !== "" ? ` Unfortunately, ${transaction.statusMessage}.` : ""}
-      </p>;
+      message = (
+        <p>
+          Your {scheduled ? "scheduled " : ""}contribution to
+          <strong> {transaction.details[0].account.name} </strong>
+          {transaction.details.length > 1
+            ? <span>and<strong> {transaction.details[1].name} </strong></span> : null}
+          was unsuccessful.
+          {transaction.statusMessage !== null && transaction.statusMessage !== ""
+            ? ` Unfortunately, ${transaction.statusMessage}.` : ""}
+        </p>
+      );
     } else if (transaction.status === "Pending") {
       status = "success";
-      message = <p>
-        Your {scheduled ? "scheduled " : ""}contribution to<strong> {transaction.details[0].account.name} </strong>
-        {transaction.details.length > 1 ? <span>and<strong> {account.details[1].name} </strong></span> : null}is <strong>pending</strong>.
-      </p>;
+      message = (
+        <p>
+          Your {scheduled ? "scheduled " : ""}contribution to
+          <strong> {transaction.details[0].account.name} </strong>
+          {transaction.details.length > 1
+            ? <span>and<strong> {transaction.details[1].name} </strong></span> : null}
+          is <strong>pending</strong>.
+        </p>
+      );
     } else {
       return null;
     }
 
     return (
       <ActivityCard
-        key={`${transaction.id.slice(0,-8)}_${transaction.details[0].account.name}`}
+        key={`${transaction.id.slice(0, -8)}_${transaction.details[0].account.name}`}
         status={status}
         date={transaction.date}
         message={message}

--- a/imports/pages/give/home/Activity.js
+++ b/imports/pages/give/home/Activity.js
@@ -183,8 +183,8 @@ export class GivingActivity extends Component {
                 {"You don't have any activity to show"}
               </h4>
               <p>
-                {`This section is to keep you up to date on your recent giving
-                activity. It appears as if you haven't given before.`}
+                {`This section is to keep you up to date on your recent online giving
+                activity. It appears as if you haven't given online before.`}
               </p>
               <p>
                 {`If you believe this is an error and you would like a member of our
@@ -198,7 +198,7 @@ export class GivingActivity extends Component {
                 </a>.
               </p>
               <Link to="/give/now" className="btn one-whole@handheld flush-bottom">
-                Give Your First Gift
+                Give Now
               </Link>
             </div>
           </div>

--- a/imports/pages/give/home/Activity.js
+++ b/imports/pages/give/home/Activity.js
@@ -180,14 +180,25 @@ export class GivingActivity extends Component {
           <div className="card">
             <div className="card__item soft">
               <h4 className="text-dark-primary">
-                Insert headline copy here
+                {"You don't have any activity to show"}
               </h4>
               <p>
-                Donec sed odio dui.
-                Integer posuere erat a ante venenatis dapibus posuere velit aliquet.
+                {`This section is to keep you up to date on your recent giving
+                activity. It appears as if you haven't given before.`}
+              </p>
+              <p>
+                {`If you believe this is an error and you would like a member of our
+                customer support team to contact you, click `}
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="//rock.newspring.cc/workflows/152?Topic=Stewardship"
+                >
+                  here
+                </a>.
               </p>
               <Link to="/give/now" className="btn one-whole@handheld flush-bottom">
-                Give First Contribution
+                Give Your First Gift
               </Link>
             </div>
           </div>

--- a/imports/pages/give/home/Activity.js
+++ b/imports/pages/give/home/Activity.js
@@ -76,12 +76,17 @@ export class GivingActivity extends Component {
     let linkUrl;
     const scheduled = transaction.schedule !== null;
 
+    // show .00 on whole-dollar amounts. Don't show on even dollars
+    const amount = transaction.details[0].amount === parseInt(transaction.details[0].amount)
+      ? transaction.details[0].amount
+      : transaction.details[0].amount.toFixed(2);
+
     if ((transaction.status === null || transaction.status === "Success" || transaction.status === "Complete") && transaction.details.length) {
       status = "success";
       linkText = "View Gift";
       linkUrl = `/give/history/${transaction.id}`;
       message =
-        `Your ${scheduled ? "scheduled " : ""}gift of $${transaction.details[0].amount} to
+        `Your ${scheduled ? "scheduled " : ""}gift of $${amount} to
         ${transaction.details[0].account.name} was successful`;
     } else if (transaction.status === "Failed") {
       status = "failed";

--- a/imports/pages/give/home/Activity.js
+++ b/imports/pages/give/home/Activity.js
@@ -36,13 +36,7 @@ export class GivingActivity extends Component {
     // separate feed by transactions and accoutns
     data.forEach((feedItem: Object) => {
       if (typeof feedItem.status !== "undefined") {
-        // there can be more than one account per transaction.
-        // separate these into separate activity cards
-        feedItem.details.map((detailItem) => {
-          const singleActivity = JSON.parse(JSON.stringify(feedItem));
-          singleActivity.details = [detailItem];
-          transactions.push(singleActivity);
-        });
+        transactions.push(feedItem);
       }
       // else {
       //   accounts.push(feedItem);
@@ -68,6 +62,16 @@ export class GivingActivity extends Component {
     return activityToShow;
   };
 
+  additionalAmount = (details) => {
+    const amount = details.amount === parseInt(details.amount)
+      ? details.amount
+      : details.amount.toFixed(2);
+
+    return (
+      <span>and <strong>${amount}</strong> to <strong>{details.account.name}</strong></span>
+    );
+  };
+
   // used by renderActivity to render a transasction card
   renderTransaction = (transaction: Object): any => {
     let message;
@@ -85,20 +89,26 @@ export class GivingActivity extends Component {
       status = "success";
       linkText = "View Gift";
       linkUrl = `/give/history/${transaction.id}`;
-      message =
-        `Your ${scheduled ? "scheduled " : ""}gift of $${amount} to
-        ${transaction.details[0].account.name} was successful`;
+      message = <p>
+        Your {scheduled ? "scheduled " : ""}gift of <strong>${amount} </strong>
+        to <strong>{transaction.details[0].account.name} </strong>
+        {transaction.details.length > 1 ? this.additionalAmount(transaction.details[1]) : null} was successful.
+      </p>;
     } else if (transaction.status === "Failed") {
       status = "failed";
-      message =
-        `Your ${scheduled ? "scheduled " : ""}contribution to ${transaction.details[0].account.name} failed.
-        ${transaction.statusMessage !== null && transaction.statusMessage !== ""
-          ? `Unfortunately, ${transaction.statusMessage}.` : ""}`;
+      message = <p>
+        Your {scheduled ? "scheduled " : ""}contribution to
+        <strong> {transaction.details[0].account.name} </strong>
+        {transaction.details.length > 1 ? <span>and<strong> {account.details[1].name} </strong></span> : null}
+        was unsuccessful.
+        {transaction.statusMessage !== null && transaction.statusMessage !== "" ? ` Unfortunately, ${transaction.statusMessage}.` : ""}
+      </p>;
     } else if (transaction.status === "Pending") {
       status = "success";
-      message =
-        `Your ${scheduled ? "scheduled " : ""}contribution to ${transaction.details[0].account.name}
-        is pending.`;
+      message = <p>
+        Your {scheduled ? "scheduled " : ""}contribution to<strong> {transaction.details[0].account.name} </strong>
+        {transaction.details.length > 1 ? <span>and<strong> {account.details[1].name} </strong></span> : null}is <strong>pending</strong>.
+      </p>;
     } else {
       return null;
     }

--- a/imports/pages/give/home/__tests__/Activity.js
+++ b/imports/pages/give/home/__tests__/Activity.js
@@ -40,7 +40,7 @@ const mockFeedData = [
     "status": null,
     "statusMessage": null,
     "schedule": null,
-    "details": [{"amount": 3,"account": {"name": "General Fund"}}]
+    "details": [{"amount": 3,"account": {"name": "General Fund"}}, {"amount": 2,"account": {"name": "Harambe Fund"}}]
   },
   {
     "id": "111",

--- a/imports/pages/give/home/__tests__/Activity.js
+++ b/imports/pages/give/home/__tests__/Activity.js
@@ -54,7 +54,7 @@ const generateComponent = (additionalProps) =>
   <GivingActivity {...additionalProps} />;
 
 describe("GivingActivity", () => {
-  it("should render with minimal props", () => {
+  it("should render with minimal props and display no activity placeholder", () => {
     const component = mount(generateComponent());
     expect(mountToJson(component)).toMatchSnapshot();
   });

--- a/imports/pages/give/home/__tests__/__snapshots__/Activity.js.snap
+++ b/imports/pages/give/home/__tests__/__snapshots__/Activity.js.snap
@@ -60,6 +60,12 @@ exports[`GivingActivity should render with data 1`] = `
               },
               "amount": 3,
             },
+            Object {
+              "account": Object {
+                "name": "Harambe Fund",
+              },
+              "amount": 2,
+            },
           ],
           "id": "789",
           "schedule": null,

--- a/imports/pages/give/home/__tests__/__snapshots__/Activity.js.snap
+++ b/imports/pages/give/home/__tests__/__snapshots__/Activity.js.snap
@@ -364,7 +364,7 @@ exports[`GivingActivity should render with data 1`] = `
 </GivingActivity>
 `;
 
-exports[`GivingActivity should render with minimal props 1`] = `
+exports[`GivingActivity should render with minimal props and display no activity placeholder 1`] = `
 <GivingActivity>
   <div
     className="soft-half-sides soft-double-sides@lap-and-up">


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- resolves #1649 
- I originally was not accounting for the fact that a single transaction can be toward multiple funds, thus the transactionDetails array 👎 . I added a contribution to each `fund` as a single activity in the feed. 
- Another option would be to have a single card with the potential to show contributions to multiple funds, i.e. `Your gift of $1 to General Fund and $0.50 to Christmas Offering was successful`. This would take a little more work, but it would keep one transaction to one card. Thoughts, @jbaxleyiii, @samclaridge ? 
- ALSO, I fixed the precision of non-whole dollar amounts to have two decimal places
- ALSO ALSO what should the blank-state copy say? Right now, its: 
![screen shot 2016-12-20 at 4 50 08 pm](https://cloud.githubusercontent.com/assets/9259509/21369323/681e841c-c6d4-11e6-8967-35216a93de6c.png)

