### PR TITLE
Clears the store when you open the saved payment modal. #1658

### DIFF
--- a/imports/pages/give/home/SavedPayments.js
+++ b/imports/pages/give/home/SavedPayments.js
@@ -37,6 +37,8 @@ export class SavedPaymentsList extends Component {
   }
 
   openModal = () => {
+    // clear out existing data
+    this.props.dispatch(giveActions.clearData());
     // set transaction type
     this.props.dispatch(giveActions.setTransactionType("savedPayment"));
     this.props.dispatch(modal.render(Give, null));


### PR DESCRIPTION
@jbaxleyiii I added the action we discussed, and it's working as expected now.  I'm going to leave the WIP just to verify that this eliminates the bug, and there aren't any outlying cases were unexpected behavior is happening.