### PR TITLE
Added browser compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,9 @@
     "React$Element": true,
     "jest": true,
   },
+  "plugins": [
+    "compat"
+  ],
   "rules": {
     "arrow-parens": [2, "always"],
     "quotes": [2, "double"],
@@ -54,6 +57,7 @@
     "import/no-extraneous-dependencies": [1],
     "no-useless-escape": 0,
     "no-cond-assign": 0,
+    "compat/compat": 1,
   },
   "settings": {
     "import/core-modules": [
@@ -61,6 +65,7 @@
       "meteor/accounts-base",
       "meteor/mongo",
       "meteor/bjwiley2:server-watch",
-    ]
+    ],
+    "targets": ["chrome", "firefox", "edge", "safari", "ie"],
   }
 }

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "eslint": "^3.6.0",
     "eslint-config-airbnb": "12.0.0",
     "eslint-config-airbnb-base": "9.0.0",
+    "eslint-plugin-compat": "^0.1.3",
     "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.4.1",


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Added the eslint-plugin-compat library so that we can check browser compatibility in our linter. Set to warnings to start with, but these could be changed to errors. 

Looks like these are the possible targets we could use:

chrome: 'Chrome',
firefox: 'Firefox',
opera: 'Opera',
safari: 'Safari',
android: 'Android Browser',
ie: 'IE',
edge: 'Edge',
ios_saf: 'iOS Safari',
op_mini: 'Opera Mini',
bb: 'Blackberry Browser',
op_mob: 'Opera Mobile',
and_chr: 'Android Chrome',
and_ff: 'Android Firefox',
ie_mob: 'IE Mobile',
and_uc: 'Android UC Browser',
samsung: 'Samsung Browser'