### PR TITLE
Zero Dollar Transactions

### DIFF
--- a/imports/pages/give/history/Layout.js
+++ b/imports/pages/give/history/Layout.js
@@ -19,8 +19,7 @@ export const TransactionList = ({ transactions }: ITransactionList) => {
         const { details, person } = transaction;
         return (
           <div key={key}>
-            {details.filter((x) => (x.account && Number(x.account) !== 0)).map((detail, i) => {
-              if (detail.amount === 0) return null;
+            {details.filter((x) => (x.amount && Number(x.amount) !== 0)).map((detail, i) => {
               const year = moment(transaction.date).year();
               if (year !== lastYear) {
                 lastYear = year;

--- a/imports/pages/give/history/Layout.js
+++ b/imports/pages/give/history/Layout.js
@@ -20,6 +20,7 @@ export const TransactionList = ({ transactions }: ITransactionList) => {
         return (
           <div key={key}>
             {details.filter((x) => (x.account && Number(x.account) !== 0)).map((detail, i) => {
+              if (detail.amount === 0) return null;
               const year = moment(transaction.date).year();
               if (year !== lastYear) {
                 lastYear = year;

--- a/imports/pages/give/history/__tests__/Layout.js
+++ b/imports/pages/give/history/__tests__/Layout.js
@@ -211,4 +211,19 @@ describe("TransactionList", () => {
     const wrapper = shallow(generateComponent({ transactions }));
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
+
+  it("doesn't render transaction with $0.00 amounts", () => {
+    const transactions = [
+      {
+        date: "2012-12-12",
+        person: {nickname: "1", photo:"1",firstName:"1",lastName:"1"},
+        details: [
+          { account: "test", amount: 0 },
+          { account: "test", amount: 1 },
+        ],
+      },
+    ];
+    const wrapper = shallow(generateComponent({ transactions }));
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
 });

--- a/imports/pages/give/history/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/pages/give/history/__tests__/__snapshots__/Layout.js.snap
@@ -363,6 +363,57 @@ exports[`Layout renders with props 1`] = `
 </div>
 `;
 
+exports[`TransactionList doesn't render transaction with $0.00 amounts 1`] = `
+<div>
+  <div>
+    <div>
+      <div
+        className="soft soft-half-left text-left">
+        <h5>
+          2012
+        </h5>
+      </div>
+      <Component
+        person={
+          Object {
+            "firstName": "1",
+            "lastName": "1",
+            "nickname": "1",
+            "photo": "1",
+          }
+        }
+        transaction={
+          Object {
+            "date": "2012-12-12",
+            "details": Array [
+              Object {
+                "account": "test",
+                "amount": 0,
+              },
+              Object {
+                "account": "test",
+                "amount": 1,
+              },
+            ],
+            "person": Object {
+              "firstName": "1",
+              "lastName": "1",
+              "nickname": "1",
+              "photo": "1",
+            },
+          }
+        }
+        transactionDetail={
+          Object {
+            "account": "test",
+            "amount": 1,
+          }
+        } />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`TransactionList renders transactions across years 1`] = `
 <div>
   <div>

--- a/imports/pages/give/home/Activity.js
+++ b/imports/pages/give/home/Activity.js
@@ -53,8 +53,10 @@ export class GivingActivity extends Component {
     // });
 
     transactions.map((transaction) => {
-      if (activityToShow.length < 3) {
-        activityToShow.push(transaction);
+      if (transaction.details[0].amount !== 0) {
+        if (activityToShow.length < 3) {
+          activityToShow.push(transaction);
+        }
       }
       return null;
     });

--- a/imports/pages/give/home/__tests__/Activity.js
+++ b/imports/pages/give/home/__tests__/Activity.js
@@ -43,6 +43,15 @@ const mockFeedData = [
     "details": [{"amount": 3,"account": {"name": "General Fund"}}, {"amount": 2,"account": {"name": "Harambe Fund"}}]
   },
   {
+    "id": "890",
+    "date": "2016-09-03",
+    "summary": "Reference Number: 89098",
+    "status": null,
+    "statusMessage": null,
+    "schedule": null,
+    "details": [{"amount": 0,"account": {"name": "General Fund"}}, {"amount": 0,"account": {"name": "Harambe Fund"}}]
+  },
+  {
     "id": "111",
     "name": "Harambe's Card",
     "expirationYear": null,

--- a/imports/pages/give/home/__tests__/__snapshots__/Activity.js.snap
+++ b/imports/pages/give/home/__tests__/__snapshots__/Activity.js.snap
@@ -74,6 +74,28 @@ exports[`GivingActivity should render with data 1`] = `
           "summary": "Reference Number: 76543",
         },
         Object {
+          "date": "2016-09-03",
+          "details": Array [
+            Object {
+              "account": Object {
+                "name": "General Fund",
+              },
+              "amount": 0,
+            },
+            Object {
+              "account": Object {
+                "name": "Harambe Fund",
+              },
+              "amount": 0,
+            },
+          ],
+          "id": "890",
+          "schedule": null,
+          "status": null,
+          "statusMessage": null,
+          "summary": "Reference Number: 89098",
+        },
+        Object {
           "expirationMonth": null,
           "expirationYear": null,
           "id": "111",


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Zero dollar transactions no longer show in the history or activity feed

# Testing/Documentation
- [x] All significant new logic is covered by tests.

Note: This may be better solved by changing Heighliner to accept high and low end dollar amount filters and using those to filter out the transactions we don't want/need. We could also use those filters in the actual history filter. Which would be good, I think.

This references https://newspring.atlassian.net/browse/SYS-3180