### PR TITLE
Fixed discover page not showing recommended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - changed giving dashboards to use progress primitive
 - removed READMEs that had nothing useful in them
 - changed some strange naming (`switch > toggle` and `toggle > tabs`) to be clearer
+
+### Fixed
+- fixed discover page not showing additional featured items

--- a/imports/components/discover/feed/__tests__/__snapshots__/index.js.snap
+++ b/imports/components/discover/feed/__tests__/__snapshots__/index.js.snap
@@ -34,6 +34,9 @@ exports[`test renders with props 1`] = `
       Object {
         "status": "featured",
       },
+      Object {
+        "status": "featured",
+      },
     ]
   }
   textItems={

--- a/imports/components/discover/feed/index.js
+++ b/imports/components/discover/feed/index.js
@@ -19,7 +19,7 @@ class DiscoverWithoutData extends Component {
     const open = discover.items.filter((x) => (x.status.toLowerCase() === "open"));
 
     const featuredItem = featured[0];
-    const recommendedItems = [...featured.slice(1, featured.length - 1)];
+    const recommendedItems = [...featured.slice(1, featured.length)];
 
     return (
       <Layout

--- a/imports/components/discover/feed/index.js
+++ b/imports/components/discover/feed/index.js
@@ -21,7 +21,6 @@ class DiscoverWithoutData extends Component {
     const featuredItem = featured[0];
     const recommendedItems = [...featured.slice(1, featured.length)];
 
-    console.log(recommendedItems);
     return (
       <Layout
         featuredItem={featuredItem}

--- a/imports/components/discover/feed/index.js
+++ b/imports/components/discover/feed/index.js
@@ -21,6 +21,7 @@ class DiscoverWithoutData extends Component {
     const featuredItem = featured[0];
     const recommendedItems = [...featured.slice(1, featured.length)];
 
+    console.log(recommendedItems);
     return (
       <Layout
         featuredItem={featuredItem}


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Fixed the discover page not showing additional recommended items.

The `slice` method's 2nd argument is exclusive and doesn't include that in the return. Since the array was length 2, we were asking for `slice(1,1)` excluding the second item in the array. 

❓ The second item shows half width on everything but phones. Do we want that?

![localhost-3000-discover ipad](https://cloud.githubusercontent.com/assets/9259509/21686380/27222b7e-d333-11e6-8989-5a802c4a8306.png)

# Screenshots
![localhost-3000-discover iphone 6](https://cloud.githubusercontent.com/assets/9259509/21685228/c68641be-d32e-11e6-9db7-6dc8ad577742.png)

