### PR TITLE
Fix to show the correct schedule date

### DIFF
--- a/imports/components/giving/cards/ScheduleCard.js
+++ b/imports/components/giving/cards/ScheduleCard.js
@@ -38,7 +38,7 @@ const ScheduleCard = ({
           >
             Start Date:
           </span>
-          <em className="text-dark-primary">{moment(started).format("MMM D, YYYY")}</em>
+          <em className="text-dark-primary">{moment.utc(started).format("MMM D, YYYY")}</em>
         </p>
         {latest && (
           <p>

--- a/imports/components/giving/cards/__tests__/ScheduleCard.js
+++ b/imports/components/giving/cards/__tests__/ScheduleCard.js
@@ -2,9 +2,9 @@ import renderer from "react-test-renderer";
 import { reset } from "aphrodite/lib/inject";
 import ScheduleOverview from "../ScheduleCard";
 
-  jest.mock("moment", () => (date) => ({
-  format: (style) => `${date || "now"}.format(${style})`,
-}));
+// jest.mock("moment", () => (date) => ({
+//   format: (style) => `${date || "now"}.format(${style})`,
+// }));
 
 describe("ScheduleOverview", () => {
   beforeEach(() => {
@@ -22,8 +22,8 @@ describe("ScheduleOverview", () => {
         baseHeadingSize="2"
         fund="Step Up Fund"
         frequency="Once A Month"
-        started="Tue Mar 15 2016 20:00:00 GMT-0400 (EDT)"
-        latest="Tue Mar 16 2016 20:00:00 GMT-0400 (EDT)"
+        started="2017-02-01"
+        latest="2017-02-02"
         onEditClick={jest.fn()}
         onDetailClick={jest.fn()}
       />
@@ -38,8 +38,8 @@ describe("ScheduleOverview", () => {
         baseHeadingSize="2"
         fund="Step Up Fund"
         frequency="Once A Month"
-        started="Tue Mar 15 2016 20:00:00 GMT-0400 (EDT)"
-        latest="Tue Mar 16 2016 20:00:00 GMT-0400 (EDT)"
+        started="2017-02-01"
+        latest="2017-02-02"
         onEditClick={jest.fn()}
         onDetailClick={jest.fn()}
       />
@@ -54,7 +54,7 @@ describe("ScheduleOverview", () => {
         baseHeadingSize="2"
         fund="Step Up Fund"
         frequency="Once A Month"
-        started="Tue Mar 15 2016 20:00:00 GMT-0400 (EDT)"
+        started="2017-02-01"
         onEditClick={jest.fn()}
         onDetailClick={jest.fn()}
       />
@@ -70,7 +70,7 @@ describe("ScheduleOverview", () => {
         baseHeadingSize="2"
         fund="Step Up Fund"
         frequency="Once A Month"
-        started="Tue Mar 15 2016 20:00:00 GMT-0400 (EDT)"
+        started="2017-02-01"
         onEditClick={jest.fn()}
         onDetailClick={jest.fn()}
       />
@@ -86,7 +86,7 @@ describe("ScheduleOverview", () => {
         baseHeadingSize="2"
         fund="Step Up Fund"
         frequency="Once A Month"
-        started="Tue Mar 15 2016 20:00:00 GMT-0400 (EDT)"
+        started="2017-02-01"
         onEditClick={jest.fn()}
         onDetailClick={jest.fn()}
       />
@@ -102,7 +102,7 @@ describe("ScheduleOverview", () => {
         baseHeadingSize="2"
         fund="Step Up Fund"
         frequency="Once A Month"
-        started="Jun 15, 2015"
+        started="2017-02-01"
         onEditClick={jest.fn()}
         onDetailClick={jest.fn()}
       />
@@ -117,7 +117,7 @@ describe("ScheduleOverview", () => {
         amount="$420.00"
         fund="Step Up Fund"
         frequency="Once A Month"
-        started="Tue Mar 15 2016 20:00:00 GMT-0400 (EDT)"
+        started="2017-02-01"
         onEditClick={jest.fn()}
         onDetailClick={jest.fn()}
       />

--- a/imports/components/giving/cards/__tests__/__snapshots__/ScheduleCard.js.snap
+++ b/imports/components/giving/cards/__tests__/__snapshots__/ScheduleCard.js.snap
@@ -57,7 +57,7 @@ exports[`ScheduleOverview correctly displays a negative value. 1`] = `
         </span>
         <em
           className="text-dark-primary">
-          Tue Mar 15 2016 20:00:00 GMT-0400 (EDT).format(MMM D, YYYY)
+          Feb 1, 2017
         </em>
       </p>
       <p>
@@ -72,7 +72,7 @@ exports[`ScheduleOverview correctly displays a negative value. 1`] = `
         </span>
         <em
           className="text-dark-primary">
-          Tue Mar 16 2016 20:00:00 GMT-0400 (EDT).format(MMM D, YYYY)
+          Feb 2, 2017
         </em>
       </p>
       <button
@@ -148,7 +148,7 @@ exports[`ScheduleOverview doesn't have a latest transaction, if one isn't passed
         </span>
         <em
           className="text-dark-primary">
-          Tue Mar 15 2016 20:00:00 GMT-0400 (EDT).format(MMM D, YYYY)
+          Feb 1, 2017
         </em>
       </p>
       <button
@@ -224,7 +224,7 @@ exports[`ScheduleOverview falls back correctly if a base heading size isn't set 
         </span>
         <em
           className="text-dark-primary">
-          Tue Mar 15 2016 20:00:00 GMT-0400 (EDT).format(MMM D, YYYY)
+          Feb 1, 2017
         </em>
       </p>
       <button
@@ -300,7 +300,7 @@ exports[`ScheduleOverview falls back correctly if currency symbol isn't present.
         </span>
         <em
           className="text-dark-primary">
-          Tue Mar 15 2016 20:00:00 GMT-0400 (EDT).format(MMM D, YYYY)
+          Feb 1, 2017
         </em>
       </p>
       <button
@@ -376,7 +376,7 @@ exports[`ScheduleOverview falls back correctly if there isn't an amount. 1`] = `
         </span>
         <em
           className="text-dark-primary">
-          Jun 15, 2015.format(MMM D, YYYY)
+          Feb 1, 2017
         </em>
       </p>
       <button
@@ -452,7 +452,7 @@ exports[`ScheduleOverview falls back correctly if there isn't any cents. 1`] = `
         </span>
         <em
           className="text-dark-primary">
-          Tue Mar 15 2016 20:00:00 GMT-0400 (EDT).format(MMM D, YYYY)
+          Feb 1, 2017
         </em>
       </p>
       <button
@@ -532,7 +532,7 @@ exports[`ScheduleOverview has an amount, fund, frequency, started, latest, onEdi
         </span>
         <em
           className="text-dark-primary">
-          Tue Mar 15 2016 20:00:00 GMT-0400 (EDT).format(MMM D, YYYY)
+          Feb 1, 2017
         </em>
       </p>
       <p>
@@ -547,7 +547,7 @@ exports[`ScheduleOverview has an amount, fund, frequency, started, latest, onEdi
         </span>
         <em
           className="text-dark-primary">
-          Tue Mar 16 2016 20:00:00 GMT-0400 (EDT).format(MMM D, YYYY)
+          Feb 2, 2017
         </em>
       </p>
       <button

--- a/imports/pages/give/schedules/Details/Layout.js
+++ b/imports/pages/give/schedules/Details/Layout.js
@@ -159,7 +159,7 @@ export default ({
                   Start Date:
                 </span>
                 <em className="text-dark-primary">
-                  {moment(schedule.start).format("MMM D, YYYY")}
+                  {moment.utc(schedule.start).format("MMM D, YYYY")}
                 </em>
               </p>
 


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Show the correct schedule date on the Schedules section of the Home tab, and on the actual schedule details page.

# Testing/Documentation
- [x] All significant new logic is covered by tests.