### PR TITLE
Added text color to the options in the select

### DIFF
--- a/imports/pages/give/home/RightPanel.js
+++ b/imports/pages/give/home/RightPanel.js
@@ -42,7 +42,7 @@ export const RightPanel = ({ loading, data, changeYear }: IRightPanel) => (
               See your summary from
           </em></small>
         </p>
-        <style>{".right-select select { color: #ffffff } .right-select:after {border-color: #ffffff transparent transparent}"}</style>
+        <style>{".right-select select { color: #ffffff } .right-select:after {border-color: #ffffff transparent transparent} .right-select select option { color: #505050 }"}</style>
         <Forms.Select
           items={YEARS}
           hideLabel

--- a/imports/pages/give/home/__tests__/__snapshots__/RightPanel.js.snap
+++ b/imports/pages/give/home/__tests__/__snapshots__/RightPanel.js.snap
@@ -99,7 +99,7 @@ exports[`RightPanel Layout should render a loading state 1`] = `
           </small>
         </p>
         <style>
-          .right-select select { color: #ffffff } .right-select:after {border-color: #ffffff transparent transparent}
+          .right-select select { color: #ffffff } .right-select:after {border-color: #ffffff transparent transparent} .right-select select option { color: #505050 }
         </style>
         <Select
           classes={
@@ -332,7 +332,7 @@ exports[`RightPanel Layout should render with data 1`] = `
           </small>
         </p>
         <style>
-          .right-select select { color: #ffffff } .right-select:after {border-color: #ffffff transparent transparent}
+          .right-select select { color: #ffffff } .right-select:after {border-color: #ffffff transparent transparent} .right-select select option { color: #505050 }
         </style>
         <Select
           classes={


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Fixed the text color of the options in the select. This seems to only affect Windows, fwiw. Mac seems to have some sort of override that auto sets the color of the text in the dropdown no matter what we set it to. This should be tested on a beta build before releasing.
- Updated test snapshots.