### PR TITLE
Fixed scheduling defect for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2017-01-10
+- Fixed an issue in iOS that was causing schedules to not be created.
+
 ## [1.2.3] - 2017-01-09
 ### Added
 - `index.js` files for folders with collections of components

--- a/imports/components/giving/checkout-views/fieldsets/shared/ActionButton.js
+++ b/imports/components/giving/checkout-views/fieldsets/shared/ActionButton.js
@@ -22,7 +22,7 @@ const ActionButton = ({
   schedule,
   scheduleToRecover,
 }: IActionButton) => {
-  if (isIOS()) {
+  if (!schedule.start && isIOS()) {
     return (
       <div>
         <p className="text-dark-secondary">

--- a/imports/components/giving/checkout-views/fieldsets/shared/__tests__/ActionButton.js
+++ b/imports/components/giving/checkout-views/fieldsets/shared/__tests__/ActionButton.js
@@ -27,3 +27,22 @@ it("should render iOS action button", () => {
   );
   expect(result).toMatchSnapshot();
 });
+
+it("should only show the iOS messages if there isn't a schedule start", () => {
+  // mock ios environment
+  global.cordova = {
+    platformId: "ios",
+  };
+  const theData = {
+    completeGift: () => {},
+    payment: {
+      type: "ach",
+      accountNumber: "123456789",
+    },
+    schedule: { start: "2017-01-10" },
+  };
+  const result = renderer.create(
+    <ActionButton { ...theData } />
+  );
+  expect(result).toMatchSnapshot();
+})

--- a/imports/components/giving/checkout-views/fieldsets/shared/__tests__/__snapshots__/ActionButton.js.snap
+++ b/imports/components/giving/checkout-views/fieldsets/shared/__tests__/__snapshots__/ActionButton.js.snap
@@ -1,3 +1,26 @@
+exports[`test should only show the iOS messages if there isn't a schedule start 1`] = `
+<button
+  className="btn soft-half-top one-whole"
+  type="submit">
+  <span>
+    Schedule With 6789
+  </span>
+     
+  <div
+    className="background--fill display-inline-block"
+    style={
+      Object {
+        "backgroundImage": "url(\'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAA8CAYAAADxJz2MAAAABGdBTUEAALGPC/xhBQAAAc9JREFUeAHt3DFOwzAUxnGcROoMEx04Q4/AoSraoXMWqp4DjgFH4AwgdWvnDlV4FoyOn+xPlVrlnwEJ+32h/eWlcqjkcGfHbrd7Op1Or8MwPNuv8zjGMSqwDyF8tG27Wq/XP+Ef78vw7kcjTKQEDl3XLRrrvC14KR937OF8Pm8bK4u3LUeFQPzIa+zHY0WWyJ/APHYghyDQjWU3m00Ym5vieN/3Q+p904EplYIxAAuwUqUAplQKxgAswEqVAphSKRgDsAArVQpgSqVgDMACrFQpgCmVgrHRJxHvHGMrcy93rfO1T150oHhFAQRQFBDjdCCAooAYpwMBFAXEePU6sHbdJL7eq4tzC4uXBEAARQExTgcCKAqIcToQQFFAjNOBAIoCYrz6SeTS/5G+lScdbmGxAwEEUBQQ43QggKKAGKcDARQFxHj1OvBW1mmijxvnFnaJ8gUA5n3cWQBdonwBgHkfdxZAlyhfAGDex50F0CXKFwCY93FnAXSJ8gUA5n3cWQBdonxBuPR3G/k/f/uzdKB4DSPgXjzHlOP7xjaR+ZyygPLeo11jO/C82EkOyommmDW842w2WzVx+6K4A48NvBkEt7PfDXHrp3fDWyyXy+9ftplH0FR79EYAAAAASUVORK5CYII=\')",
+        "borderRadius": "3px",
+        "height": "21px",
+        "position": "inherit",
+        "top": "3px",
+        "width": "30px",
+      }
+    } />
+</button>
+`;
+
 exports[`test should render iOS action button 1`] = `
 <div>
   <p


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Fixed the issue where you couldn't create a schedule on any iOS device. It was opening a modal with schedule details and taking you out into the browser. None of this should have been happening.

# Testing/Documentation
- [ ] All significant new logic is covered by tests.
- [ ] Changelog has been updated.