### PR TITLE
fixed potential logic issue in tags

### DIFF
--- a/imports/components/@primitives/UI/tags/index.js
+++ b/imports/components/@primitives/UI/tags/index.js
@@ -38,9 +38,8 @@ class TagWithoutData extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (
-        (this.props.active || this.isInQueryString(nextProps)) &&
-        nextProps.canBeActive &&
-        nextProps.active
+        (nextProps.active || this.isInQueryString(nextProps)) &&
+        nextProps.canBeActive
       ) {
       this.setState({ isActive: true });
     } else if (nextProps.active && nextProps.canBeActive && !this.props.active) {

--- a/imports/routes.js
+++ b/imports/routes.js
@@ -1,5 +1,6 @@
-import ChildrenRoutes from "./pages";
+
 import { Meteor } from "meteor/meteor";
+import ChildrenRoutes from "./pages";
 
 if (process.env.NATIVE) {
   // eslint-disable-next-line no-unused-vars
@@ -29,7 +30,7 @@ export default {
     if (process.env.NATIVE && _.location.pathname === "/") {
       return redirectToWelcome(replace, cb);
     } else if (process.env.WEB && _.location.pathname === "/") {
-      if(Meteor.userId()) {
+      if (Meteor.userId()) {
         replace({ pathname: "/give/home" });
       } else {
         replace({ pathname: "/give/now" });

--- a/imports/routes.js
+++ b/imports/routes.js
@@ -1,4 +1,5 @@
 import ChildrenRoutes from "./pages";
+import { Meteor } from "meteor/meteor";
 
 if (process.env.NATIVE) {
   // eslint-disable-next-line no-unused-vars
@@ -28,7 +29,11 @@ export default {
     if (process.env.NATIVE && _.location.pathname === "/") {
       return redirectToWelcome(replace, cb);
     } else if (process.env.WEB && _.location.pathname === "/") {
-      replace({ pathname: "/give/home" });
+      if(Meteor.userId()) {
+        replace({ pathname: "/give/home" });
+      } else {
+        replace({ pathname: "/give/now" });
+      }
       return cb();
     }
     return cb();


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Tags at the top of groupfinder results were not showing as active after full page load

`componentWillReceiveProps` was checking for both `inQueryString` AND `nextProps.active`.
I think this is supposed to be checking for either. That and current props.active shoulrn't matter, right? It wasn't being set to active because although it was in the query string, the nextProps weren't `active`.

# Screenshots
![jan-15-2017 10-30-59](https://cloud.githubusercontent.com/assets/9259509/21963735/c2ca6b86-db0d-11e6-925a-3cb20dededb3.gif)
- I also checked to make sure the group cards below were showing correctly.
- It also doesn't break schedules  
![jan-15-2017 10-34-42](https://cloud.githubusercontent.com/assets/9259509/21963774/514705b8-db0e-11e6-80ab-36176d812293.gif)

