### PR TITLE
fixed import for toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2017-01-10
+## [Unreleased]
+### Fixed
 - Fixed an issue in iOS that was causing schedules to not be created.
+- Fixed the toggle import in the `/following` section on profile causing component not to render.
 
 ## [1.2.3] - 2017-01-09
 ### Added

--- a/imports/components/people/profile/following/Item.js
+++ b/imports/components/people/profile/following/Item.js
@@ -1,6 +1,6 @@
 import { PropTypes } from "react";
 
-import { Toggle } from "../../../@primitives/UI/toggle/Toggle";
+import Toggle from "../../../@primitives/UI/toggle/Toggle";
 
 const FollowingItem = ({ item, changed, switchId, active }) => (
   <div className="push-left soft-ends soft-right text-left floating outlined--light outlined--bottom">
@@ -23,4 +23,3 @@ FollowingItem.propTypes = {
 };
 
 export default FollowingItem;
-


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- The following tab was not displaying
- The import for that component was trying to use a named import, when it was a default export, causing render errors. 

![jan-22-2017 14-20-02](https://cloud.githubusercontent.com/assets/9259509/22185136/04e23c9c-e0ae-11e6-85c3-0140a8843872.gif)
