### PR TITLE
Likable Enhancer & GROUPS 🎉

### DIFF
--- a/imports/components/@enhancers/can-like/index.js
+++ b/imports/components/@enhancers/can-like/index.js
@@ -3,6 +3,7 @@ import { Meteor } from "meteor/meteor";
 import React, { Component } from "react";
 import { graphql } from "react-apollo";
 import gql from "graphql-tag";
+import { connect } from "react-redux";
 
 import { liked as likedActions, modal } from "../../../data/store";
 import OnBoard from "../../people/accounts";
@@ -19,72 +20,27 @@ const TOGGLE_LIKE_MUTATION = gql`
 
 const withToggleLike = graphql(TOGGLE_LIKE_MUTATION);
 
-/*
-  THIS NEEDS TO BE WRAPPED IN A CONNECT CALL TO WORK
-  THE CONNECT CALL MUST REVEAL
+export const ClassWrapper = (propsReducer) => (WrappedComponent) => {
+  export class LikesWrapper extends Component {
+    getNodeId = () => propsReducer(this.props);
 
-  How this works:
-    it's a function.
-    inside the function, I'm declaring a class
-      * it has to be inside the function so I have access to the `WrappedComponent`
-      the class (LikesWrapper) returns the WrappedComponent with prop for toggling like (onLike)
-    at the bottom of the function I return:
-      the LikesWrapper class wrapped in a gql mutation.
-    So the export is...
-      a function that takes a React Component, and returns that component wrapped in
-      a LikesWrapper HOC which is wrapped in a GraphQl HOC that allows the toggleLike mutation
-*/
-export default (WrappedComponent) => {
-  class LikesWrapper extends Component {
-    constructor(props){
-      super(props);
-      this.state = { liked: false, id: null }
-      this.toggleLike = this.toggleLike.bind(this);
-    }
-
-    componentWillReceiveProps(nextProps){
-      // gets the node id from gql data passed in. sets the local state `id`
-      this.getNodeId(nextProps);
-    }
-
-    getNodeId(props) {
-      if(props){
-        const keys = Object.keys(props);
-        const contentKey = keys.find((key) => {
-          return props[key] && props[key].content
-        });
-
-        if(!contentKey) return null;
-        const id = props[contentKey].content.id || props[contentKey].content.entryId;
-        if(this.state.id != id){
-          this.setState({ id: id });
-        }
-        return id;
-      }
-    }
-
-    toggleLike() {
+    toggleLike = () => {
+      const { dispatch, mutate } = this.props;
       if (!Meteor.userId()) { //if not logged in, show login modal
-        this.props.dispatch(modal.render(OnBoard, {
-          coverHeader: true,
-          modalBackground: "light",
+        dispatch(modal.render(OnBoard, {
+          coverHeader: true, modalBackground: "light",
         }));
       } else { // if logged in, toggle like state in redux, remote with gql query
-        this.props.dispatch(likedActions.toggle({
-          entryId: this.state.id,
-        }));
-        this.props.mutate({ variables: { nodeId: this.state.id } })
+        dispatch(likedActions.toggle({ entryId: this.getNodeId() }));
+        mutate({ variables: { nodeId: this.getNodeId() } });
       }
 
-      return {
-        type: "FALSY",
-        payload: {},
-      };
+      return { type: "FALSY", payload: {} };
     }
 
-    render() {
-      return <WrappedComponent {...this.props} onLike={this.toggleLike} />
-    }
+    render = () => <WrappedComponent {...this.props} onLike={this.toggleLike} />;
   }
   return withToggleLike(LikesWrapper); // the actual component to be wrapped in a function
 }
+
+export default ClassWrapper;

--- a/imports/components/@enhancers/can-like/index.js
+++ b/imports/components/@enhancers/can-like/index.js
@@ -22,71 +22,59 @@ const withToggleLike = graphql(TOGGLE_LIKE_MUTATION);
 /*
   THIS NEEDS TO BE WRAPPED IN A CONNECT CALL TO WORK
 */
-
-export class LikesWrapper extends Component {
-  constructor(props){
-    super(props);
-    this.state = { liked: false, id: null }
-    this.toggleLike = this.toggleLike.bind(this);
-  }
-
-  componentWillMount(){
-    // TODO get whether already liked and set the button state
-  }
-
-  componentWillReceiveProps(nextProps){
-    // gets the node id from gql data passed in. sets the local state `id`
-    this.getNodeId(nextProps);
-    console.log("PROPS", nextProps);
-  }
-
-  getNodeId(props) {
-    if(props){
-      const keys = Object.keys(props);
-      const contentKey = keys.find((key) => {
-        return props[key] && props[key].content
-      });
-
-      if(!contentKey) return null;
-      const id = props[contentKey].content.id || props[contentKey].content.entryId;
-      if(this.state.id != id){
-        this.setState({ id: id });
-      }
-      return id;
-    }
-  }
-
-  toggleLike() {
-    console.log("TOGGLE LIKE CLICKED");
-    //if not logged in, show login modal
-    if (!Meteor.userId()) {
-      this.props.dispatch(modal.render(OnBoard, {
-        coverHeader: true,
-        modalBackground: "light",
-      }));
-    } else { // if logged in, toggle like state in redux, remote with gql query
-      this.props.dispatch(likedActions.toggle({
-        entryId: this.state.id,
-      }));
-      // this.updateDatabase(entry);
-      // this.props.mutate
-    }
-
-    return {
-      type: "FALSY",
-      payload: {},
-    };
-  }
-
-  render() {
-    return <WrappedComponent {...this.props} onLike={this.toggleLike} />
-  }
-}
-
-// wrap the wrapper class in a gql HOC
-export const WithMutation = withToggleLike(LikesWrapper);
-
-//wrap the data-wrapped class with a function
 export default (WrappedComponent) => {
-  return WithMutation;
-};
+  class LikesWrapper extends Component {
+    constructor(props){
+      super(props);
+      this.state = { liked: false, id: null }
+      this.toggleLike = this.toggleLike.bind(this);
+    }
+
+    componentWillReceiveProps(nextProps){
+      // gets the node id from gql data passed in. sets the local state `id`
+      this.getNodeId(nextProps);
+      console.log("PROPS", nextProps);
+    }
+
+    getNodeId(props) {
+      if(props){
+        const keys = Object.keys(props);
+        const contentKey = keys.find((key) => {
+          return props[key] && props[key].content
+        });
+
+        if(!contentKey) return null;
+        const id = props[contentKey].content.id || props[contentKey].content.entryId;
+        if(this.state.id != id){
+          this.setState({ id: id });
+        }
+        return id;
+      }
+    }
+
+    toggleLike() {
+      if (!Meteor.userId()) { //if not logged in, show login modal
+        this.props.dispatch(modal.render(OnBoard, {
+          coverHeader: true,
+          modalBackground: "light",
+        }));
+      } else { // if logged in, toggle like state in redux, remote with gql query
+        this.props.dispatch(likedActions.toggle({
+          entryId: this.state.id,
+        }));
+        this.props.mutate({ variables: { nodeId: this.state.id } })
+          // .then((x) => console.log("toggled:", x));
+      }
+
+      return {
+        type: "FALSY",
+        payload: {},
+      };
+    }
+
+    render() {
+      return <WrappedComponent {...this.props} onLike={this.toggleLike} />
+    }
+  }
+  return withToggleLike(LikesWrapper); // the actual component to be wrapped in a function
+}

--- a/imports/components/@enhancers/can-like/index.js
+++ b/imports/components/@enhancers/can-like/index.js
@@ -1,0 +1,92 @@
+
+import { Meteor } from "meteor/meteor";
+import React, { Component } from "react";
+import { graphql } from "react-apollo";
+import gql from "graphql-tag";
+
+import { liked as likedActions, modal } from "../../../data/store";
+import OnBoard from "../../people/accounts";
+
+const TOGGLE_LIKE_MUTATION = gql`
+  mutation ToggleLike($nodeId: String!) {
+    toggleLike(nodeId: $nodeId) {
+      like {
+        id
+      }
+    }
+  }
+`;
+
+const withToggleLike = graphql(TOGGLE_LIKE_MUTATION);
+
+/*
+  THIS NEEDS TO BE WRAPPED IN A CONNECT CALL TO WORK
+*/
+
+export class LikesWrapper extends Component {
+  constructor(props){
+    super(props);
+    this.state = { liked: false, id: null }
+    this.toggleLike = this.toggleLike.bind(this);
+  }
+
+  componentWillMount(){
+    // TODO get whether already liked and set the button state
+  }
+
+  componentWillReceiveProps(nextProps){
+    // gets the node id from gql data passed in. sets the local state `id`
+    this.getNodeId(nextProps);
+    console.log("PROPS", nextProps);
+  }
+
+  getNodeId(props) {
+    if(props){
+      const keys = Object.keys(props);
+      const contentKey = keys.find((key) => {
+        return props[key] && props[key].content
+      });
+
+      if(!contentKey) return null;
+      const id = props[contentKey].content.id || props[contentKey].content.entryId;
+      if(this.state.id != id){
+        this.setState({ id: id });
+      }
+      return id;
+    }
+  }
+
+  toggleLike() {
+    console.log("TOGGLE LIKE CLICKED");
+    //if not logged in, show login modal
+    if (!Meteor.userId()) {
+      this.props.dispatch(modal.render(OnBoard, {
+        coverHeader: true,
+        modalBackground: "light",
+      }));
+    } else { // if logged in, toggle like state in redux, remote with gql query
+      this.props.dispatch(likedActions.toggle({
+        entryId: this.state.id,
+      }));
+      // this.updateDatabase(entry);
+      // this.props.mutate
+    }
+
+    return {
+      type: "FALSY",
+      payload: {},
+    };
+  }
+
+  render() {
+    return <WrappedComponent {...this.props} onLike={this.toggleLike} />
+  }
+}
+
+// wrap the wrapper class in a gql HOC
+export const WithMutation = withToggleLike(LikesWrapper);
+
+//wrap the data-wrapped class with a function
+export default (WrappedComponent) => {
+  return WithMutation;
+};

--- a/imports/components/@enhancers/can-like/index.js
+++ b/imports/components/@enhancers/can-like/index.js
@@ -21,6 +21,18 @@ const withToggleLike = graphql(TOGGLE_LIKE_MUTATION);
 
 /*
   THIS NEEDS TO BE WRAPPED IN A CONNECT CALL TO WORK
+  THE CONNECT CALL MUST REVEAL
+
+  How this works:
+    it's a function.
+    inside the function, I'm declaring a class
+      * it has to be inside the function so I have access to the `WrappedComponent`
+      the class (LikesWrapper) returns the WrappedComponent with prop for toggling like (onLike)
+    at the bottom of the function I return:
+      the LikesWrapper class wrapped in a gql mutation.
+    So the export is...
+      a function that takes a React Component, and returns that component wrapped in
+      a LikesWrapper HOC which is wrapped in a GraphQl HOC that allows the toggleLike mutation
 */
 export default (WrappedComponent) => {
   class LikesWrapper extends Component {
@@ -33,7 +45,6 @@ export default (WrappedComponent) => {
     componentWillReceiveProps(nextProps){
       // gets the node id from gql data passed in. sets the local state `id`
       this.getNodeId(nextProps);
-      console.log("PROPS", nextProps);
     }
 
     getNodeId(props) {
@@ -63,7 +74,6 @@ export default (WrappedComponent) => {
           entryId: this.state.id,
         }));
         this.props.mutate({ variables: { nodeId: this.state.id } })
-          // .then((x) => console.log("toggled:", x));
       }
 
       return {

--- a/imports/components/@enhancers/likes/__tests__/__snapshots__/toggle.js.snap
+++ b/imports/components/@enhancers/likes/__tests__/__snapshots__/toggle.js.snap
@@ -14,7 +14,7 @@ fragment ContentCard on Content {
   title
   channelName
   content {
-    images(sizes: [\"SMALL\", \"MEDIUM\"]) {
+    images(sizes: ["SMALL", "MEDIUM"]) {
       url
       label
     }
@@ -36,7 +36,9 @@ exports[`Likes Wrapper should render the child component 1`] = `
     Object {
       "dispatch": [Function],
       "getState": [Function],
+      "replaceReducer": [Function],
       "subscribe": [Function],
+      Symbol(observable): [Function],
     }
   }>
   <ApolloProvider
@@ -50,7 +52,9 @@ exports[`Likes Wrapper should render the child component 1`] = `
       Object {
         "dispatch": [Function],
         "getState": [Function],
+        "replaceReducer": [Function],
         "subscribe": [Function],
+        Symbol(observable): [Function],
       }
     }>
     <Connect(Apollo(LikesWrapper))

--- a/imports/components/@enhancers/likes/__tests__/__snapshots__/toggle.js.snap
+++ b/imports/components/@enhancers/likes/__tests__/__snapshots__/toggle.js.snap
@@ -1,0 +1,54 @@
+exports[`Likes Wrapper should contain mutation 1`] = `
+"mutation ToggleLike($nodeId: String!) {
+  toggleLike(nodeId: $nodeId) {
+    like {
+      id
+    }
+  }
+}
+"
+`;
+
+exports[`Likes Wrapper should render the child component 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "subscribe": [Function],
+    }
+  }>
+  <ApolloProvider
+    client={
+      Object {
+        "initStore": [Function],
+        "mutate": [Function],
+      }
+    }
+    store={
+      Object {
+        "dispatch": [Function],
+        "getState": [Function],
+        "subscribe": [Function],
+      }
+    }>
+    <Connect(Apollo(LikesWrapper))>
+      <Apollo(LikesWrapper)
+        dispatch={[Function]}>
+        <LikesWrapper
+          dispatch={[Function]}
+          mutate={[Function]}>
+          <TestComponent
+            dispatch={[Function]}
+            mutate={[Function]}>
+            <div
+              id="tester">
+              Test
+            </div>
+          </TestComponent>
+        </LikesWrapper>
+      </Apollo(LikesWrapper)>
+    </Connect(Apollo(LikesWrapper))>
+  </ApolloProvider>
+</Provider>
+`;

--- a/imports/components/@enhancers/likes/__tests__/__snapshots__/toggle.js.snap
+++ b/imports/components/@enhancers/likes/__tests__/__snapshots__/toggle.js.snap
@@ -2,9 +2,30 @@ exports[`Likes Wrapper should contain mutation 1`] = `
 "mutation ToggleLike($nodeId: String!) {
   toggleLike(nodeId: $nodeId) {
     like {
-      id
+      ...ContentCard
+      ...GroupCard
     }
   }
+}
+
+fragment ContentCard on Content {
+  __typename
+  id
+  title
+  channelName
+  content {
+    images(sizes: [\"SMALL\", \"MEDIUM\"]) {
+      url
+      label
+    }
+  }
+}
+
+fragment GroupCard on Group {
+  __typename
+  id
+  name
+  photo
 }
 "
 `;
@@ -32,14 +53,34 @@ exports[`Likes Wrapper should render the child component 1`] = `
         "subscribe": [Function],
       }
     }>
-    <Connect(Apollo(LikesWrapper))>
+    <Connect(Apollo(LikesWrapper))
+      modal={
+        Object {
+          "visible": false,
+        }
+      }>
       <Apollo(LikesWrapper)
-        dispatch={[Function]}>
+        dispatch={[Function]}
+        modal={
+          Object {
+            "visible": false,
+          }
+        }>
         <LikesWrapper
           dispatch={[Function]}
+          modal={
+            Object {
+              "visible": false,
+            }
+          }
           mutate={[Function]}>
           <TestComponent
             dispatch={[Function]}
+            modal={
+              Object {
+                "visible": false,
+              }
+            }
             mutate={[Function]}>
             <div
               id="tester">

--- a/imports/components/@enhancers/likes/__tests__/toggle.js
+++ b/imports/components/@enhancers/likes/__tests__/toggle.js
@@ -24,11 +24,14 @@ const mockClient = {
 Meteor.userId = jest.fn();
 
 const renderComponent = (additionalProps) => {
+  const defaultProps = {
+    modal: { visible: false },
+  }
   const Wrapped = classWrapper(jest.fn(() => "12345"))(TestComponent);
   return (
     <Provider store={mockStore}>
       <ApolloProvider client={mockClient} store={mockStore}>
-        <Wrapped {...additionalProps} />
+        <Wrapped { ...defaultProps } { ...additionalProps } />
       </ApolloProvider>
     </Provider>
   );
@@ -95,7 +98,7 @@ describe("Likes Wrapper", () => {
     const Component = (
       <Provider store={mockStore}>
         <ApolloProvider client={mockClient} store={mockStore}>
-          <Wrapped />
+          <Wrapped modal={{visible: false}} />
         </ApolloProvider>
       </Provider>
     );
@@ -118,7 +121,7 @@ describe("Likes Wrapper", () => {
     const Component = (
       <Provider store={mockStore}>
         <ApolloProvider client={mockClient} store={mockStore}>
-          <Wrapped />
+          <Wrapped modal={{visible: false}} />
         </ApolloProvider>
       </Provider>
     );

--- a/imports/components/@enhancers/likes/__tests__/toggle.js
+++ b/imports/components/@enhancers/likes/__tests__/toggle.js
@@ -1,14 +1,166 @@
 
-import { classWrapper } from "../toggle";
+import { print } from "graphql-tag/printer";
+import { ApolloProvider } from 'react-apollo';
+import { mount } from "enzyme";
+import { Provider } from 'react-redux';
+import { mountToJson } from "enzyme-to-json";
+import { Meteor } from "meteor/meteor";
+
+import { classWrapper, TOGGLE_LIKE_MUTATION } from "../toggle";
+
+const TestComponent = (props) => <div id="tester">Test</div>;
+
+const mockStore = {
+  getState: jest.fn(),
+  subscribe: jest.fn(),
+  dispatch: jest.fn(),
+};
+
+const mockClient = {
+  initStore: jest.fn(),
+  mutate: jest.fn(),
+};
+
+Meteor.userId = jest.fn();
+
+const renderComponent = (additionalProps) => {
+  const Wrapped = classWrapper(jest.fn(() => "12345"))(TestComponent);
+  return (
+    <Provider store={mockStore}>
+      <ApolloProvider client={mockClient} store={mockStore}>
+        <Wrapped {...additionalProps} />
+      </ApolloProvider>
+    </Provider>
+  );
+};
 
 describe("Likes Wrapper", () => {
 
-  beforeEach(() => {
-
+  it("should contain mutation", () => {
+    expect(print(TOGGLE_LIKE_MUTATION)).toMatchSnapshot();
   });
 
-  it("", () => {
-
+  it("should render the child component", () => {
+    const component = mount(renderComponent());
+    expect(mountToJson(component)).toMatchSnapshot();
   });
 
+  it("should pass props to the wrapped component properly", () => {
+    const component = mount(renderComponent({
+      prop1: "hello",
+      iMiss: "harambe",
+    }));
+
+    const passedProps = component.find(TestComponent).props();
+    expect("prop1" in passedProps).toEqual(true);
+    expect("iMiss" in passedProps).toEqual(true);
+  });
+
+  it("should dispatch nav actions on mount", () => {
+    mockStore.dispatch.mockReset();
+    const component = mount(renderComponent());
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(2)
+    expect(mockStore.dispatch.mock.calls[0][0]).toEqual({
+      "level": "CONTENT", "type": "NAV.SET_LEVEL"
+    });
+    expect(mockStore.dispatch.mock.calls[1][0].level).toEqual("CONTENT");
+    expect(mockStore.dispatch.mock.calls[1][0].type).toEqual("NAV.SET_ACTION");
+  });
+
+  it("should dispatch nav actions on unmount", () => {
+    const component = mount(renderComponent());
+    mockStore.dispatch.mockReset();
+    component.unmount();
+
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(1)
+    expect(mockStore.dispatch.mock.calls[0][0]).toEqual({
+      "level": "TOP", "type": "NAV.SET_LEVEL"
+    });
+  });
+
+  it("should dispatch modal on toggleLike if no user", () => {
+    mockStore.dispatch.mockReset();
+    const component = mount(renderComponent());
+
+    // look into the dispatch calls to get access to the toggleLike
+    const toggle = mockStore.dispatch.mock.calls[1][0].props.action;
+    toggle();
+
+    expect(mockStore.dispatch.mock.calls[2][0].type).toEqual("MODAL.SET_CONTENT");
+  });
+
+  it("should not dispatch if user but no nodeId", () => {
+    mockStore.dispatch.mockReset();
+    const Wrapped = classWrapper(jest.fn())(TestComponent);
+    const Component = (
+      <Provider store={mockStore}>
+        <ApolloProvider client={mockClient} store={mockStore}>
+          <Wrapped />
+        </ApolloProvider>
+      </Provider>
+    );
+
+    // when mounting, it calls an action to set the trigger for toggling a like.
+    const component = mount(Component);
+
+    // look into the dispatch calls to get access to the toggleLike
+    const toggle = mockStore.dispatch.mock.calls[1][0].props.action;
+    Meteor.userId.mockReturnValueOnce("123");
+    toggle();
+
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("should return null when getNodeId is called with no reducer", () => {
+    mockStore.dispatch.mockReset();
+
+    const Wrapped = classWrapper()(TestComponent);
+    const Component = (
+      <Provider store={mockStore}>
+        <ApolloProvider client={mockClient} store={mockStore}>
+          <Wrapped />
+        </ApolloProvider>
+      </Provider>
+    );
+
+    // when mounting, it calls an action to set the trigger for toggling a like.
+    const component = mount(Component);
+
+    // look into the dispatch calls to get access to the toggleLike
+    const toggle = mockStore.dispatch.mock.calls[1][0].props.action;
+    Meteor.userId.mockReturnValueOnce("1234");
+    toggle();
+
+    // since there,s no reducer, the dispatch from toggle won't get called
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("should dispatch and call mutate in toggleLike if user and nodeId present", () => {
+    mockStore.dispatch.mockReset();
+    const component = mount(renderComponent());
+
+    // look into the dispatch calls to get access to the toggleLike
+    const toggle = mockStore.dispatch.mock.calls[1][0].props.action;
+    Meteor.userId.mockReturnValueOnce("1234");
+    toggle();
+
+    expect(mockStore.dispatch).toHaveBeenCalledTimes(3);
+    expect(mockStore.dispatch.mock.calls[2][0]).toEqual({
+      props: {entryId: "12345"},
+      type: "LIKED.TOGGLE",
+    });
+    expect(mockClient.mutate).toBeCalled();
+  });
+
+  it("should return properly from toggleLike", () => {
+    mockStore.dispatch.mockReset();
+    const component = mount(renderComponent());
+
+    // look into the dispatch calls to get access to the toggleLike
+    const toggle = mockStore.dispatch.mock.calls[1][0].props.action;
+    Meteor.userId.mockReturnValueOnce("1234");
+    const res = toggle();
+
+    expect(res).toEqual({ type: "FALSY", payload: {} });
+  });
 });

--- a/imports/components/@enhancers/likes/__tests__/toggle.js
+++ b/imports/components/@enhancers/likes/__tests__/toggle.js
@@ -1,0 +1,14 @@
+
+import { classWrapper } from "../toggle";
+
+describe("Likes Wrapper", () => {
+
+  beforeEach(() => {
+
+  });
+
+  it("", () => {
+
+  });
+
+});

--- a/imports/components/@enhancers/likes/__tests__/toggle.js
+++ b/imports/components/@enhancers/likes/__tests__/toggle.js
@@ -5,6 +5,8 @@ import { mount } from "enzyme";
 import { Provider } from 'react-redux';
 import { mountToJson } from "enzyme-to-json";
 import { Meteor } from "meteor/meteor";
+import { connect } from "react-redux";
+import { createStore } from "redux";
 
 import { classWrapper, TOGGLE_LIKE_MUTATION } from "../toggle";
 
@@ -14,6 +16,7 @@ const mockStore = {
   getState: jest.fn(),
   subscribe: jest.fn(),
   dispatch: jest.fn(),
+  modal: { visible: false },
 };
 
 const mockClient = {
@@ -29,9 +32,9 @@ const renderComponent = (additionalProps) => {
   }
   const Wrapped = classWrapper(jest.fn(() => "12345"))(TestComponent);
   return (
-    <Provider store={mockStore}>
-      <ApolloProvider client={mockClient} store={mockStore}>
-        <Wrapped { ...defaultProps } { ...additionalProps } />
+    <Provider store={createStore(() => mockStore, mockStore)}>
+      <ApolloProvider client={mockClient} store={createStore(() => mockStore, mockStore)}>
+        <Wrapped modal={{ visible: false }} { ...additionalProps } />
       </ApolloProvider>
     </Provider>
   );
@@ -43,7 +46,7 @@ describe("Likes Wrapper", () => {
     expect(print(TOGGLE_LIKE_MUTATION)).toMatchSnapshot();
   });
 
-  it("should render the child component", () => {
+  fit("should render the child component", () => {
     const component = mount(renderComponent());
     expect(mountToJson(component)).toMatchSnapshot();
   });

--- a/imports/components/@enhancers/likes/fragments.js
+++ b/imports/components/@enhancers/likes/fragments.js
@@ -1,0 +1,26 @@
+
+import gql from "graphql-tag";
+
+export const contentCard = gql`
+  fragment ContentCard on Content {
+    __typename
+    id
+    title
+    channelName
+    content {
+      images(sizes: ["SMALL", "MEDIUM"]) {
+        url
+        label
+      }
+    }
+  }
+`;
+
+export const groupCard = gql`
+  fragment GroupCard on Group {
+    __typename
+    id
+    name
+    photo
+  }
+`;

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -45,6 +45,10 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
       }));
     }
 
+    componentWillUnmount() {
+      this.props.dispatch(navActions.setLevel("TOP"));
+    }
+
     getNodeId = () => {
       if (propsReducer && typeof propsReducer === "function") {
         return propsReducer(this.props);
@@ -54,6 +58,8 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
     };
 
     toggleLike = () => {
+      console.log("PROPS", this.props);
+      console.log("NODE", this.getNodeId());
       const { dispatch, mutate } = this.props;
       if (!Meteor.userId()) { // if not logged in, show login modal
         dispatch(modal.render(OnBoard, {

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -61,10 +61,9 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
     };
 
     toggleLike = () => {
-      console.log("PROPS", this.props);
       const { dispatch, mutate } = this.props;
-      // may still be open form user logging in.
-      if (this.props.modal && this.props.modal.visible) dispatch(modal.hide());
+      // may still be open from user logging in.
+      if (Meteor.userId() && this.props.modal && this.props.modal.visible) dispatch(modal.hide());
 
       if (!Meteor.userId()) { // if not logged in, show login modal
         dispatch(modal.render(OnBoard, {
@@ -86,8 +85,8 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
     render = () => <WrappedComponent {...this.props} />;
   }
 
-  const mapStateToProps = ({ modal }) => ({
-    modal: modal,
+  const mapStateToProps = (state) => ({
+    modal: state.modal
   });
 
   return connect(mapStateToProps)(withToggleLike(LikesWrapper));

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -61,9 +61,10 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
     };
 
     toggleLike = () => {
+      console.log("PROPS", this.props);
       const { dispatch, mutate } = this.props;
       // may still be open form user logging in.
-      if (this.props.modal.visible) dispatch(modal.hide());
+      if (this.props.modal && this.props.modal.visible) dispatch(modal.hide());
 
       if (!Meteor.userId()) { // if not logged in, show login modal
         dispatch(modal.render(OnBoard, {
@@ -84,7 +85,12 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
 
     render = () => <WrappedComponent {...this.props} />;
   }
-  return connect()(withToggleLike(LikesWrapper));
+
+  const mapStateToProps = ({ modal }) => ({
+    modal: modal,
+  });
+
+  return connect(mapStateToProps)(withToggleLike(LikesWrapper));
 };
 
 export default classWrapper;

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -8,22 +8,25 @@ import { graphql } from "react-apollo";
 import gql from "graphql-tag";
 import { connect } from "react-redux";
 
+import { contentCard, groupCard } from "./fragments";
 import {
   nav as navActions,
   liked as likedActions,
   modal,
 } from "../../../data/store";
-
 import OnBoard from "../../people/accounts";
 
 export const TOGGLE_LIKE_MUTATION = gql`
   mutation ToggleLike($nodeId: String!) {
     toggleLike(nodeId: $nodeId) {
       like {
-        id
+        ... ContentCard
+        ... GroupCard
       }
     }
   }
+  ${contentCard}
+  ${groupCard}
 `;
 
 const withToggleLike = graphql(TOGGLE_LIKE_MUTATION, {});

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -1,4 +1,7 @@
 
+// @flow
+
+// $FlowMeteor
 import { Meteor } from "meteor/meteor";
 import React, { Component } from "react";
 import { graphql } from "react-apollo";
@@ -18,30 +21,36 @@ const TOGGLE_LIKE_MUTATION = gql`
   }
 `;
 
-const withToggleLike = graphql(TOGGLE_LIKE_MUTATION);
+const withToggleLike = graphql(TOGGLE_LIKE_MUTATION, {});
 
-export const classWrapper = (propsReducer) => (WrappedComponent) => {
-  export class LikesWrapper extends Component {
+export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) => {
+  type ILikesWrapper = {
+    dispatch: Function,
+    mutate: Function,
+  };
+
+  class LikesWrapper extends Component {
+    props: ILikesWrapper;
+
     getNodeId = () => {
-      if(propsReducer && typeof propsReducer === "function" ) {
-          return propsReducer(this.props);
-      } else {
-        console.warn("propsReducer was either not passed, or is not a function")
-        return null;
-      };
+      if (propsReducer && typeof propsReducer === "function") {
+        return propsReducer(this.props);
+      }
+      console.warn("propsReducer was either not passed, or is not a function");
+      return null;
     };
 
     toggleLike = () => {
       const { dispatch, mutate } = this.props;
-      if (!Meteor.userId()) { //if not logged in, show login modal
+      if (!Meteor.userId()) { // if not logged in, show login modal
         dispatch(modal.render(OnBoard, {
           coverHeader: true, modalBackground: "light",
         }));
       } else { // if logged in, toggle like state in redux, remote with gql query
         const nodeId = this.getNodeId();
-        if(nodeId) {
+        if (nodeId) {
           dispatch(likedActions.toggle({ entryId: nodeId }));
-          mutate({ variables: { nodeId: nodeId } });
+          mutate({ variables: { nodeId } });
         }
       }
 
@@ -50,7 +59,7 @@ export const classWrapper = (propsReducer) => (WrappedComponent) => {
 
     render = () => <WrappedComponent {...this.props} onLike={this.toggleLike} />;
   }
-  return connect()(withToggleLike(LikesWrapper)); // the actual component to be wrapped in a function
-}
+  return connect()(withToggleLike(LikesWrapper));
+};
 
 export default classWrapper;

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -62,9 +62,14 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
 
     toggleLike = () => {
       const { dispatch, mutate } = this.props;
+      // may still be open form user logging in.
+      if (this.props.modal.visible) dispatch(modal.hide());
+
       if (!Meteor.userId()) { // if not logged in, show login modal
         dispatch(modal.render(OnBoard, {
-          coverHeader: true, modalBackground: "light",
+          coverHeader: true,
+          modalBackground: "light",
+          onFinished: this.toggleLike,
         }));
       } else { // if logged in, toggle like state in redux, remote with gql query
         const nodeId = this.getNodeId();

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -11,7 +11,7 @@ import { connect } from "react-redux";
 import {
   nav as navActions,
   liked as likedActions,
-  modal
+  modal,
 } from "../../../data/store";
 
 import OnBoard from "../../people/accounts";
@@ -58,8 +58,6 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
     };
 
     toggleLike = () => {
-      console.log("PROPS", this.props);
-      console.log("NODE", this.getNodeId());
       const { dispatch, mutate } = this.props;
       if (!Meteor.userId()) { // if not logged in, show login modal
         dispatch(modal.render(OnBoard, {

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -16,7 +16,7 @@ import {
 
 import OnBoard from "../../people/accounts";
 
-const TOGGLE_LIKE_MUTATION = gql`
+export const TOGGLE_LIKE_MUTATION = gql`
   mutation ToggleLike($nodeId: String!) {
     toggleLike(nodeId: $nodeId) {
       like {
@@ -74,7 +74,7 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
       return { type: "FALSY", payload: {} };
     }
 
-    render = () => <WrappedComponent {...this.props} onLike={this.toggleLike} />;
+    render = () => <WrappedComponent {...this.props} />;
   }
   return connect()(withToggleLike(LikesWrapper));
 };

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -20,7 +20,7 @@ const TOGGLE_LIKE_MUTATION = gql`
 
 const withToggleLike = graphql(TOGGLE_LIKE_MUTATION);
 
-export const ClassWrapper = (propsReducer) => (WrappedComponent) => {
+export const classWrapper = (propsReducer) => (WrappedComponent) => {
   export class LikesWrapper extends Component {
     getNodeId = () => propsReducer(this.props);
 
@@ -40,7 +40,7 @@ export const ClassWrapper = (propsReducer) => (WrappedComponent) => {
 
     render = () => <WrappedComponent {...this.props} onLike={this.toggleLike} />;
   }
-  return withToggleLike(LikesWrapper); // the actual component to be wrapped in a function
+  return connect()(withToggleLike(LikesWrapper)); // the actual component to be wrapped in a function
 }
 
-export default ClassWrapper;
+export default classWrapper;

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -35,6 +35,7 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
   type ILikesWrapper = {
     dispatch: Function,
     mutate: Function,
+    modal: Object,
   };
 
   class LikesWrapper extends Component {
@@ -86,7 +87,7 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
   }
 
   const mapStateToProps = (state) => ({
-    modal: state.modal
+    modal: state.modal,
   });
 
   return connect(mapStateToProps)(withToggleLike(LikesWrapper));

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -8,7 +8,12 @@ import { graphql } from "react-apollo";
 import gql from "graphql-tag";
 import { connect } from "react-redux";
 
-import { liked as likedActions, modal } from "../../../data/store";
+import {
+  nav as navActions,
+  liked as likedActions,
+  modal
+} from "../../../data/store";
+
 import OnBoard from "../../people/accounts";
 
 const TOGGLE_LIKE_MUTATION = gql`
@@ -31,6 +36,14 @@ export const classWrapper = (propsReducer: Function) => (WrappedComponent: any) 
 
   class LikesWrapper extends Component {
     props: ILikesWrapper;
+
+    componentWillMount() {
+      this.props.dispatch(navActions.setLevel("CONTENT"));
+      this.props.dispatch(navActions.setAction("CONTENT", {
+        id: 2,
+        action: this.toggleLike,
+      }));
+    }
 
     getNodeId = () => {
       if (propsReducer && typeof propsReducer === "function") {

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -22,7 +22,14 @@ const withToggleLike = graphql(TOGGLE_LIKE_MUTATION);
 
 export const classWrapper = (propsReducer) => (WrappedComponent) => {
   export class LikesWrapper extends Component {
-    getNodeId = () => propsReducer(this.props);
+    getNodeId = () => {
+      if(propsReducer && typeof propsReducer === "function" ) {
+          return propsReducer(this.props);
+      } else {
+        console.warn("propsReducer was either not passed, or is not a function")
+        return null;
+      };
+    };
 
     toggleLike = () => {
       const { dispatch, mutate } = this.props;
@@ -31,8 +38,11 @@ export const classWrapper = (propsReducer) => (WrappedComponent) => {
           coverHeader: true, modalBackground: "light",
         }));
       } else { // if logged in, toggle like state in redux, remote with gql query
-        dispatch(likedActions.toggle({ entryId: this.getNodeId() }));
-        mutate({ variables: { nodeId: this.getNodeId() } });
+        const nodeId = this.getNodeId();
+        if(nodeId) {
+          dispatch(likedActions.toggle({ entryId: nodeId }));
+          mutate({ variables: { nodeId: nodeId } });
+        }
       }
 
       return { type: "FALSY", payload: {} };

--- a/imports/data/store/accounts/reducer.js
+++ b/imports/data/store/accounts/reducer.js
@@ -243,22 +243,20 @@ export default createReducer(initial, {
       return state;
     }
 
-    const personAction = JSON.parse(JSON.stringify(action.person));
-
-    if (!personAction.Home) {
+    if (!action.person.Home) {
       // eslint-disable-next-line
-      personAction.Home = initial.person.Home;
+      action.person.Home = initial.person.Home;
     }
 
-    if (!personAction.Campus) {
+    if (!action.person.Campus) {
       // eslint-disable-next-line
-      personAction.Campus = initial.person.Campus;
+      action.person.Campus = initial.person.Campus;
     }
 
     return {
       ...state,
       ...{
-        person: personAction,
+        person: action.person,
         authorized: true,
       },
     };

--- a/imports/data/store/accounts/reducer.js
+++ b/imports/data/store/accounts/reducer.js
@@ -243,20 +243,22 @@ export default createReducer(initial, {
       return state;
     }
 
-    if (!action.person.Home) {
+    const personAction = JSON.parse(JSON.stringify(action.person));
+
+    if (!personAction.Home) {
       // eslint-disable-next-line
-      action.person.Home = initial.person.Home;
+      personAction.Home = initial.person.Home;
     }
 
-    if (!action.person.Campus) {
+    if (!personAction.Campus) {
       // eslint-disable-next-line
-      action.person.Campus = initial.person.Campus;
+      personAction.Campus = initial.person.Campus;
     }
 
     return {
       ...state,
       ...{
-        person: action.person,
+        person: personAction,
         authorized: true,
       },
     };

--- a/imports/data/store/liked/index.js
+++ b/imports/data/store/liked/index.js
@@ -12,6 +12,7 @@
 */
 import reducer from "./reducer";
 import { addReducer } from "../utilities";
+import "./saga";
 
 addReducer({
   liked: reducer,

--- a/imports/data/store/liked/saga.js
+++ b/imports/data/store/liked/saga.js
@@ -1,13 +1,13 @@
 /* eslint-disable import/no-named-as-default-member */
 import "regenerator-runtime/runtime";
-import { takeLatest, takeEvery } from "redux-saga";
-import { fork, put, cps, select } from "redux-saga/effects";
+import { takeEvery } from "redux-saga";
+import { fork, put } from "redux-saga/effects";
 
 import { addSaga } from "../utilities";
 
 import actions from "./";
 
-function* signout({ state }){
+function* signout({ state }) {
   if (state !== "signout") return;
   yield put(actions.set([]));
 }

--- a/imports/data/store/liked/saga.js
+++ b/imports/data/store/liked/saga.js
@@ -1,0 +1,17 @@
+/* eslint-disable import/no-named-as-default-member */
+import "regenerator-runtime/runtime";
+import { takeLatest, takeEvery } from "redux-saga";
+import { fork, put, cps, select } from "redux-saga/effects";
+
+import { addSaga } from "../utilities";
+
+import actions from "./";
+
+function* signout({ state }){
+  if (state !== "signout") return;
+  yield put(actions.set([]));
+}
+
+addSaga(function* likedSaga() {
+  yield fork(takeEvery, "ACCOUNTS.SET_STATE", signout);
+});

--- a/imports/data/store/sections/saga.js
+++ b/imports/data/store/sections/saga.js
@@ -97,17 +97,15 @@ function* getSectionsData() {
 
   // go ahead and make the query on load (this will be cached on heighliner)
   const { data } = yield GraphQL.query({ query, variables });
-  // XXX cloned this because we need navigation to not be frozen
-  const navigation = JSON.parse(JSON.stringify(data.navigation));
+  const navigation = data.navigation;
+  delete data.navigation;
   const filteredItems = {};
 
   // parse the results and only get a single usable image
   // eslint-disable-next-line
   for (const item in data) {
-    if(item !== "navigation"){
-      const image = extractImage(data[item][0]);
-      filteredItems[item] = image;
-    }
+    const image = extractImage(data[item][0]);
+    filteredItems[item] = image;
   }
 
   function bindForeignImages(sections) {

--- a/imports/data/store/sections/saga.js
+++ b/imports/data/store/sections/saga.js
@@ -1,3 +1,6 @@
+
+// XXX we need to abstract this to the component level
+
 import "regenerator-runtime/runtime";
 
 import { fork, put } from "redux-saga/effects";
@@ -94,15 +97,17 @@ function* getSectionsData() {
 
   // go ahead and make the query on load (this will be cached on heighliner)
   const { data } = yield GraphQL.query({ query, variables });
-  const navigation = data.navigation;
-  delete data.navigation;
+  // XXX cloned this because we need navigation to not be frozen
+  const navigation = JSON.parse(JSON.stringify(data.navigation));
   const filteredItems = {};
 
   // parse the results and only get a single usable image
   // eslint-disable-next-line
   for (const item in data) {
-    const image = extractImage(data[item][0]);
-    filteredItems[item] = image;
+    if(item !== "navigation"){
+      const image = extractImage(data[item][0]);
+      filteredItems[item] = image;
+    }
   }
 
   function bindForeignImages(sections) {

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -1,4 +1,4 @@
-import { Component, PropTypes } from "react";
+import { PropTypes } from "react";
 import ReactMixin from "react-mixin";
 import { connect } from "react-redux";
 import { graphql } from "react-apollo";
@@ -24,74 +24,71 @@ import Content from "./Content";
 
 const defaultArray = [];
 
-class ArticlesSingle extends Component {
+const ArticlesSingle = (props) => {
+  const { content } = props.article;
 
-  static propTypes = {
-    article: PropTypes.object.isRequired,
-  }
-
-  render() {
-    const { content } = this.props.article;
-
-    if (!content) {
-      // loading
-      return (
-        <div className="locked-ends locked-sides floating">
-          <div className="floating__item">
-            <Loading />
-          </div>
-        </div>
-      );
-    }
-
-    const article = content;
-    const photo = backgrounds.image(article);
+  if (!content) {
+    // loading
     return (
-      <div>
-        <Meta
-          title={article.title}
-          image={photo}
-          id={article.id}
-          meta={[
-            { property: "og:type", content: "article" },
-          ]}
-        />
-        <Split nav classes={["background--light-primary"]}>
-          {(() => {
-            if (article.content.ooyalaId.length === 0) {
-              return (
-                <Right
-                  mobile
-                  background={photo}
-                  classes={["floating--bottom", "overlay--gradient@lap-and-up"]}
-                  ratioClasses={["floating__item", "overlay__item", "one-whole", "soft@lap-and-up"]}
-                  aspect="square"
-                />
-              );
-            }
-            return <SingleVideoPlayer ooyalaId={article.content.ooyalaId} />;
-          })()}
-        </Split>
-        <Left scroll >
-          <div className="one-whole">
-            <section
-              className={
-                "soft@palm soft-double-sides@palm-wide-and-up soft@lap " +
-                "soft-double@lap-wide-and-up push-top push-double-top@lap-and-up"
-              }
-            >
-              <Content article={article} />
-            </section>
-            <RelatedContent
-              excludedIds={[article.id]}
-              tags={article.content.tags || defaultArray}
-            />
-          </div>
-        </Left>
+      <div className="locked-ends locked-sides floating">
+        <div className="floating__item">
+          <Loading />
+        </div>
       </div>
     );
   }
-}
+
+  const article = content;
+  const photo = backgrounds.image(article);
+  return (
+    <div>
+      <Meta
+        title={article.title}
+        image={photo}
+        id={article.id}
+        meta={[
+          { property: "og:type", content: "article" },
+        ]}
+      />
+      <Split nav classes={["background--light-primary"]}>
+        {(() => {
+          if (article.content.ooyalaId.length === 0) {
+            return (
+              <Right
+                mobile
+                background={photo}
+                classes={["floating--bottom", "overlay--gradient@lap-and-up"]}
+                ratioClasses={["floating__item", "overlay__item", "one-whole", "soft@lap-and-up"]}
+                aspect="square"
+              />
+            );
+          }
+          return <SingleVideoPlayer ooyalaId={article.content.ooyalaId} />;
+        })()}
+      </Split>
+      <Left scroll >
+        <div className="one-whole">
+          <section
+            className={
+              "soft@palm soft-double-sides@palm-wide-and-up soft@lap " +
+              "soft-double@lap-wide-and-up push-top push-double-top@lap-and-up"
+            }
+          >
+            <Content article={article} />
+          </section>
+          <RelatedContent
+            excludedIds={[article.id]}
+            tags={article.content.tags || defaultArray}
+          />
+        </div>
+      </Left>
+    </div>
+  );
+};
+
+ArticlesSingle.propTypes = {
+  article: PropTypes.object.isRequired,
+};
 
 const ARTICLE_QUERY = gql`
   query getArticle($id: ID!) {

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -27,9 +27,7 @@ const defaultArray = [];
 class ArticlesSingle extends Component {
 
   static propTypes = {
-    dispatch: PropTypes.func.isRequired,
     article: PropTypes.object.isRequired,
-    onLike: PropTypes.function,
   }
 
   render() {

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -19,9 +19,9 @@ import RelatedContent from "../../components/content/related-content";
 
 import SingleVideoPlayer from "../../components/@primitives/players/video/Player";
 
-import {
-  nav as navActions,
-} from "../../data/store";
+// import {
+//   nav as navActions,
+// } from "../../data/store";
 
 // import content component
 import Content from "./Content";
@@ -38,11 +38,11 @@ class ArticlesSingle extends Component {
 
   componentWillMount() {
     if (process.env.WEB) return;
-    this.props.dispatch(navActions.setLevel("CONTENT"));
-    this.props.dispatch(navActions.setAction("CONTENT", {
-      id: 2,
-      action: this.props.onLike,
-    }));
+    // this.props.dispatch(navActions.setLevel("CONTENT"));
+    // this.props.dispatch(navActions.setAction("CONTENT", {
+    //   id: 2,
+    //   action: this.props.onLike,
+    // }));
   }
 
   render() {

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -11,6 +11,7 @@ import Headerable from "../../deprecated/mixins/mixins.Header";
 import Likeable from "../../deprecated/mixins/mixins.Likeable";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 import CanLike from "../../components/@enhancers/can-like";
+console.log("CANLIKe", CanLike);
 
 import Loading from "../../components/@primitives/UI/loading";
 

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -8,10 +8,8 @@ import Meta from "../../components/shared/meta";
 // loading state
 import Split, { Left, Right } from "../../components/@primitives/layout/split";
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import Likeable from "../../deprecated/mixins/mixins.Likeable";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 import CanLike from "../../components/@enhancers/can-like";
-console.log("CANLIKe", CanLike);
 
 import Loading from "../../components/@primitives/UI/loading";
 
@@ -42,7 +40,7 @@ class ArticlesSingle extends Component {
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
-      action: this.props.onLike, // pass from props?
+      action: this.props.onLike,
     }));
   }
 
@@ -147,18 +145,13 @@ const withArticle = graphql(ARTICLE_QUERY, {
   }),
 });
 
-const Single = CanLike(ArticlesSingle);
-
 export default connect()(
   withArticle(
-    Single
-  //   ReactMixin.decorate(Likeable)(
-  //     ReactMixin.decorate(Shareable)(
-  //       ReactMixin.decorate(Headerable)(
-  //         ArticlesSingle
-  //       )
-  //     )
-  //   )
+    ReactMixin.decorate(Shareable)(
+      ReactMixin.decorate(Headerable)(
+        CanLike(ArticlesSingle)
+      )
+    )
   )
 );
 

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -33,6 +33,7 @@ class ArticlesSingle extends Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     article: PropTypes.object.isRequired,
+    onLike: PropTypes.function,
   }
 
   componentWillMount() {
@@ -149,7 +150,9 @@ export default connect()(
   withArticle(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        canLike((props) => props.article.loading ? null : props.article.content.id)(ArticlesSingle)
+        canLike(
+          (props) => (props.article.loading ? null : props.article.content.id)
+        )(ArticlesSingle)
       )
     )
   )

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -10,6 +10,7 @@ import Split, { Left, Right } from "../../components/@primitives/layout/split";
 import Headerable from "../../deprecated/mixins/mixins.Header";
 import Likeable from "../../deprecated/mixins/mixins.Likeable";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
+import CanLike from "../../components/@enhancers/can-like";
 
 import Loading from "../../components/@primitives/UI/loading";
 
@@ -40,7 +41,7 @@ class ArticlesSingle extends Component {
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
-      action: this.likeableAction,
+      action: this.props.onLike, // pass from props?
     }));
   }
 
@@ -145,15 +146,18 @@ const withArticle = graphql(ARTICLE_QUERY, {
   }),
 });
 
+const Single = CanLike(ArticlesSingle);
+
 export default connect()(
   withArticle(
-    ReactMixin.decorate(Likeable)(
-      ReactMixin.decorate(Shareable)(
-        ReactMixin.decorate(Headerable)(
-          ArticlesSingle
-        )
-      )
-    )
+    Single
+  //   ReactMixin.decorate(Likeable)(
+  //     ReactMixin.decorate(Shareable)(
+  //       ReactMixin.decorate(Headerable)(
+  //         ArticlesSingle
+  //       )
+  //     )
+  //   )
   )
 );
 

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -19,10 +19,6 @@ import RelatedContent from "../../components/content/related-content";
 
 import SingleVideoPlayer from "../../components/@primitives/players/video/Player";
 
-// import {
-//   nav as navActions,
-// } from "../../data/store";
-
 // import content component
 import Content from "./Content";
 
@@ -34,15 +30,6 @@ class ArticlesSingle extends Component {
     dispatch: PropTypes.func.isRequired,
     article: PropTypes.object.isRequired,
     onLike: PropTypes.function,
-  }
-
-  componentWillMount() {
-    if (process.env.WEB) return;
-    // this.props.dispatch(navActions.setLevel("CONTENT"));
-    // this.props.dispatch(navActions.setAction("CONTENT", {
-    //   id: 2,
-    //   action: this.props.onLike,
-    // }));
   }
 
   render() {

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -1,4 +1,7 @@
-import { PropTypes } from "react";
+
+// @flow
+// ignore mixin until we can remove it entirely
+// $FlowMeteor
 import ReactMixin from "react-mixin";
 import { connect } from "react-redux";
 import { graphql } from "react-apollo";
@@ -24,7 +27,11 @@ import Content from "./Content";
 
 const defaultArray = [];
 
-const ArticlesSingle = (props) => {
+type IArticlesSingle = {
+  article: Object,
+};
+
+const ArticlesSingle = (props: IArticlesSingle) => {
   const { content } = props.article;
 
   if (!content) {
@@ -84,10 +91,6 @@ const ArticlesSingle = (props) => {
       </Left>
     </div>
   );
-};
-
-ArticlesSingle.propTypes = {
-  article: PropTypes.object.isRequired,
 };
 
 const ARTICLE_QUERY = gql`

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -9,7 +9,7 @@ import Meta from "../../components/shared/meta";
 import Split, { Left, Right } from "../../components/@primitives/layout/split";
 import Headerable from "../../deprecated/mixins/mixins.Header";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
-import CanLike from "../../components/@enhancers/can-like";
+import canLike from "../../components/@enhancers/likes/toggle";
 
 import Loading from "../../components/@primitives/UI/loading";
 
@@ -149,7 +149,7 @@ export default connect()(
   withArticle(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike((props) => props.article.loading ? null : props.article.content.id)(ArticlesSingle)
+        canLike((props) => props.article.loading ? null : props.article.content.id)(ArticlesSingle)
       )
     )
   )

--- a/imports/pages/articles/Single.js
+++ b/imports/pages/articles/Single.js
@@ -149,7 +149,7 @@ export default connect()(
   withArticle(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike(ArticlesSingle)
+        CanLike((props) => props.article.loading ? null : props.article.content.id)(ArticlesSingle)
       )
     )
   )

--- a/imports/pages/articles/__tests__/Single.js
+++ b/imports/pages/articles/__tests__/Single.js
@@ -1,9 +1,6 @@
 import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
 import { ArticlesSingleWithoutData as ArticlesSingle } from "../Single";
-import {
-  nav as navActions,
-} from "../../../data/store";
 
 jest.mock("../../../deprecated/mixins/mixins.Likeable", () => {});
 jest.mock("../../../deprecated/mixins/mixins.Header", () => {});
@@ -63,18 +60,4 @@ it("renders video if ooyalaId", () => {
     },
   }));
   expect(shallowToJson(wrapper)).toMatchSnapshot();
-});
-
-it("dispatches nav actions on mount", () => {
-  const mockDispatch = jest.fn();
-  navActions.setLevel = jest.fn();
-  navActions.setAction = jest.fn();
-  const wrapper = shallow(generateComponent({
-    dispatch: mockDispatch,
-  }));
-  expect(mockDispatch).toHaveBeenCalledTimes(2);
-  expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  expect(navActions.setAction).toHaveBeenCalledTimes(1);
-  expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
 });

--- a/imports/pages/devotionals/Single.js
+++ b/imports/pages/devotionals/Single.js
@@ -8,7 +8,7 @@ import Meta from "../../components/shared/meta";
 
 import Loading from "../../components/@primitives/UI/loading";
 
-import CanLike from "../../components/@enhancers/can-like";
+import canLike from "../../components/@enhancers/likes/toggle";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 import {
@@ -239,7 +239,7 @@ const mapStateToProps = (state) => ({
 export default connect(mapStateToProps)(
   withDevotional(
     ReactMixin.decorate(Shareable)(
-      CanLike((props) => props.devotion.loading ? null : props.devotion.content.id)(DevotionsSingle)
+      canLike((props) => props.devotion.loading ? null : props.devotion.content.id)(DevotionsSingle)
     )
   )
 );

--- a/imports/pages/devotionals/Single.js
+++ b/imports/pages/devotionals/Single.js
@@ -26,7 +26,6 @@ class DevotionsSingle extends Component {
     dispatch: PropTypes.func.isRequired,
     live: PropTypes.object.isRequired,
     devotion: PropTypes.object.isRequired,
-    onLike: PropTypes.function,
   }
 
   state = { selectedIndex: 0 }

--- a/imports/pages/devotionals/Single.js
+++ b/imports/pages/devotionals/Single.js
@@ -12,7 +12,6 @@ import canLike from "../../components/@enhancers/likes/toggle";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 import {
-  nav as navActions,
   header as headerActions,
   live as liveActions,
 } from "../../data/store";
@@ -42,12 +41,6 @@ class DevotionsSingle extends Component {
     this.props.dispatch(liveActions.hide());
     // for cached data
     this.handleLiveBar(this.props, this.state);
-
-    this.props.dispatch(navActions.setLevel("CONTENT"));
-    this.props.dispatch(navActions.setAction("CONTENT", {
-      id: 2,
-      action: this.props.onLike,
-    }));
 
     this.props.dispatch(headerActions.set({}));
     this.props.dispatch(headerActions.hide());

--- a/imports/pages/devotionals/Single.js
+++ b/imports/pages/devotionals/Single.js
@@ -27,6 +27,7 @@ class DevotionsSingle extends Component {
     dispatch: PropTypes.func.isRequired,
     live: PropTypes.object.isRequired,
     devotion: PropTypes.object.isRequired,
+    onLike: PropTypes.function,
   }
 
   state = { selectedIndex: 0 }
@@ -239,7 +240,9 @@ const mapStateToProps = (state) => ({
 export default connect(mapStateToProps)(
   withDevotional(
     ReactMixin.decorate(Shareable)(
-      canLike((props) => props.devotion.loading ? null : props.devotion.content.id)(DevotionsSingle)
+      canLike(
+        (props) => (props.devotion.loading ? null : props.devotion.content.id)
+      )(DevotionsSingle)
     )
   )
 );

--- a/imports/pages/devotionals/Single.js
+++ b/imports/pages/devotionals/Single.js
@@ -8,7 +8,7 @@ import Meta from "../../components/shared/meta";
 
 import Loading from "../../components/@primitives/UI/loading";
 
-import Likeable from "../../deprecated/mixins/mixins.Likeable";
+import CanLike from "../../components/@enhancers/can-like";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 import {
@@ -45,7 +45,7 @@ class DevotionsSingle extends Component {
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
-      action: this.likeableAction,
+      action: this.props.onLike,
     }));
 
     this.props.dispatch(headerActions.set({}));
@@ -238,10 +238,8 @@ const mapStateToProps = (state) => ({
 
 export default connect(mapStateToProps)(
   withDevotional(
-    ReactMixin.decorate(Likeable)(
-      ReactMixin.decorate(Shareable)(
-        DevotionsSingle
-      )
+    ReactMixin.decorate(Shareable)(
+      CanLike(DevotionsSingle)
     )
   )
 );

--- a/imports/pages/devotionals/Single.js
+++ b/imports/pages/devotionals/Single.js
@@ -239,7 +239,7 @@ const mapStateToProps = (state) => ({
 export default connect(mapStateToProps)(
   withDevotional(
     ReactMixin.decorate(Shareable)(
-      CanLike(DevotionsSingle)
+      CanLike((props) => props.devotion.loading ? null : props.devotion.content.id)(DevotionsSingle)
     )
   )
 );

--- a/imports/pages/devotionals/__tests__/Single.js
+++ b/imports/pages/devotionals/__tests__/Single.js
@@ -96,19 +96,19 @@ it("renders with scripture", () => {
 it("dispatches to the store on mount", () => {
   const mockDispatch = jest.fn();
   liveActions.hide = jest.fn();
-  navActions.setLevel = jest.fn();
-  navActions.setAction = jest.fn();
+  // navActions.setLevel = jest.fn();
+  // navActions.setAction = jest.fn();
   headerActions.set = jest.fn();
   headerActions.hide = jest.fn();
   const wrapper = shallow(generateComponent({
     dispatch: mockDispatch,
   }));
-  expect(mockDispatch).toHaveBeenCalledTimes(5);
+  expect(mockDispatch).toHaveBeenCalledTimes(3);
   expect(liveActions.hide).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  expect(navActions.setAction).toHaveBeenCalledTimes(1);
-  expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
+  // expect(navActions.setLevel).toHaveBeenCalledTimes(1);
+  // expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
+  // expect(navActions.setAction).toHaveBeenCalledTimes(1);
+  // expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
   expect(headerActions.set).toHaveBeenCalledTimes(1);
   expect(headerActions.hide).toHaveBeenCalledTimes(1);
 });
@@ -159,7 +159,7 @@ it("unfloats the live bar on unmount", () => {
     dispatch: mockDispatch,
   }));
   wrapper.instance().componentWillUnmount();
-  expect(mockDispatch).toHaveBeenCalledTimes(6);
+  expect(mockDispatch).toHaveBeenCalledTimes(4);
   expect(liveActions.unfloat).toHaveBeenCalledTimes(1);
 });
 

--- a/imports/pages/devotionals/__tests__/Single.js
+++ b/imports/pages/devotionals/__tests__/Single.js
@@ -96,8 +96,6 @@ it("renders with scripture", () => {
 it("dispatches to the store on mount", () => {
   const mockDispatch = jest.fn();
   liveActions.hide = jest.fn();
-  // navActions.setLevel = jest.fn();
-  // navActions.setAction = jest.fn();
   headerActions.set = jest.fn();
   headerActions.hide = jest.fn();
   const wrapper = shallow(generateComponent({
@@ -105,10 +103,6 @@ it("dispatches to the store on mount", () => {
   }));
   expect(mockDispatch).toHaveBeenCalledTimes(3);
   expect(liveActions.hide).toHaveBeenCalledTimes(1);
-  // expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  // expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  // expect(navActions.setAction).toHaveBeenCalledTimes(1);
-  // expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
   expect(headerActions.set).toHaveBeenCalledTimes(1);
   expect(headerActions.hide).toHaveBeenCalledTimes(1);
 });

--- a/imports/pages/groups/profile/__tests__/index.js
+++ b/imports/pages/groups/profile/__tests__/index.js
@@ -105,7 +105,6 @@ it("closeModal calls preventDefault, hides modal, and adjust nav", () => {
   const mockPreventDefault = jest.fn();
   const mockDispatch = jest.fn();
   modal.hide = jest.fn();
-  // navActions.setLevel = jest.fn();
   const wrapper = shallow(generateComponent({
     dispatch: mockDispatch,
   }));
@@ -115,8 +114,6 @@ it("closeModal calls preventDefault, hides modal, and adjust nav", () => {
   expect(mockPreventDefault).toHaveBeenCalledTimes(1);
   expect(mockDispatch).toHaveBeenCalledTimes(1);
   expect(modal.hide).toHaveBeenCalledTimes(1);
-  // expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  // expect(navActions.setLevel).toHaveBeenCalledWith("BASIC_CONTENT");
 });
 
 it("sendRequest calls preventDefault and the join meteor method", () => {

--- a/imports/pages/groups/profile/__tests__/index.js
+++ b/imports/pages/groups/profile/__tests__/index.js
@@ -1,7 +1,7 @@
 import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
 import { Meteor } from "meteor/meteor";
-import { nav as navActions, modal } from "../../../../data/store";
+import { modal } from "../../../../data/store";
 import OnBoard from "../../../../components/people/accounts";
 import Join from "../Join";
 import { TemplateWithoutData as Template } from "../";
@@ -105,7 +105,7 @@ it("closeModal calls preventDefault, hides modal, and adjust nav", () => {
   const mockPreventDefault = jest.fn();
   const mockDispatch = jest.fn();
   modal.hide = jest.fn();
-  navActions.setLevel = jest.fn();
+  // navActions.setLevel = jest.fn();
   const wrapper = shallow(generateComponent({
     dispatch: mockDispatch,
   }));
@@ -113,10 +113,10 @@ it("closeModal calls preventDefault, hides modal, and adjust nav", () => {
     preventDefault: mockPreventDefault,
   });
   expect(mockPreventDefault).toHaveBeenCalledTimes(1);
-  expect(mockDispatch).toHaveBeenCalledTimes(2);
+  expect(mockDispatch).toHaveBeenCalledTimes(1);
   expect(modal.hide).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledWith("BASIC_CONTENT");
+  // expect(navActions.setLevel).toHaveBeenCalledTimes(1);
+  // expect(navActions.setLevel).toHaveBeenCalledWith("BASIC_CONTENT");
 });
 
 it("sendRequest calls preventDefault and the join meteor method", () => {

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -12,7 +12,7 @@ import GoogleMap from "../../../components/@primitives/map";
 import Loading from "../../../components/@primitives/UI/loading";
 
 import Headerable from "../../../deprecated/mixins/mixins.Header";
-import canLike from "../../components/@enhancers/likes/toggle";
+import canLike from "../../../components/@enhancers/likes/toggle";
 
 import { nav as navActions, modal } from "../../../data/store";
 

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -12,6 +12,7 @@ import GoogleMap from "../../../components/@primitives/map";
 import Loading from "../../../components/@primitives/UI/loading";
 
 import Headerable from "../../../deprecated/mixins/mixins.Header";
+import CanLike from "../../../components/@enhancers/can-like";
 
 import { nav as navActions, modal } from "../../../data/store";
 
@@ -30,6 +31,12 @@ class TemplateWithoutData extends Component {
     if (this.headerAction) {
       this.headerAction({ title: "Group Profile" });
     }
+    if (process.env.WEB) return;
+    this.props.dispatch(navActions.setLevel("CONTENT"));
+    this.props.dispatch(navActions.setAction("CONTENT", {
+      id: 2,
+      action: this.props.onLike,
+    }));
   }
 
   componentWillUnmount() {
@@ -175,12 +182,17 @@ const withGroup = graphql(GROUP_QUERY, {
   options: (ownProps) => ({
     variables: { id: ownProps.params.id },
   }),
+  props: ({ ownProps, data }) => ({
+    ...ownProps,
+    data: data,
+    group: { content: data.group } // CanLike needs this structure
+  })
 });
 
 export default connect()(
   withGroup(
     ReactMixin.decorate(Headerable)(
-      TemplateWithoutData
+      CanLike(TemplateWithoutData)
     )
   )
 );

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -182,17 +182,12 @@ const withGroup = graphql(GROUP_QUERY, {
   options: (ownProps) => ({
     variables: { id: ownProps.params.id },
   }),
-  props: ({ ownProps, data }) => ({
-    ...ownProps,
-    data: data,
-    group: { content: data.group } // CanLike needs this structure
-  })
 });
 
 export default connect()(
   withGroup(
     ReactMixin.decorate(Headerable)(
-      CanLike(TemplateWithoutData)
+      CanLike((props) => props.data.loading ? null : props.data.group.id)(TemplateWithoutData)
     )
   )
 );

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -25,6 +25,7 @@ class TemplateWithoutData extends Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     data: PropTypes.object.isRequired,
+    onLike: PropTypes.function,
   }
 
   componentWillMount() {
@@ -187,7 +188,9 @@ const withGroup = graphql(GROUP_QUERY, {
 export default connect()(
   withGroup(
     ReactMixin.decorate(Headerable)(
-      canLike((props) => props.data.loading ? null : props.data.group.id)(TemplateWithoutData)
+      canLike(
+        (props) => (props.data.loading ? null : props.data.group.id)
+      )(TemplateWithoutData)
     )
   )
 );

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -14,6 +14,8 @@ import Loading from "../../../components/@primitives/UI/loading";
 import Headerable from "../../../deprecated/mixins/mixins.Header";
 import canLike from "../../../components/@enhancers/likes/toggle";
 
+import { modal } from "../../../data/store";
+
 import Layout from "./Layout";
 import Join from "./Join";
 
@@ -23,7 +25,6 @@ class TemplateWithoutData extends Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     data: PropTypes.object.isRequired,
-    onLike: PropTypes.function,
   }
 
   componentWillMount() {
@@ -39,7 +40,6 @@ class TemplateWithoutData extends Component {
   closeModal = (e) => {
     if (e && e.preventDefault) e.preventDefault();
     this.props.dispatch(modal.hide());
-    this.props.dispatch(navActions.setLevel("BASIC_CONTENT"));
   }
 
   sendRequest = (e, callback) => {

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -12,7 +12,7 @@ import GoogleMap from "../../../components/@primitives/map";
 import Loading from "../../../components/@primitives/UI/loading";
 
 import Headerable from "../../../deprecated/mixins/mixins.Header";
-import CanLike from "../../../components/@enhancers/can-like";
+import canLike from "../../components/@enhancers/likes/toggle";
 
 import { nav as navActions, modal } from "../../../data/store";
 
@@ -187,7 +187,7 @@ const withGroup = graphql(GROUP_QUERY, {
 export default connect()(
   withGroup(
     ReactMixin.decorate(Headerable)(
-      CanLike((props) => props.data.loading ? null : props.data.group.id)(TemplateWithoutData)
+      canLike((props) => props.data.loading ? null : props.data.group.id)(TemplateWithoutData)
     )
   )
 );

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -14,8 +14,6 @@ import Loading from "../../../components/@primitives/UI/loading";
 import Headerable from "../../../deprecated/mixins/mixins.Header";
 import canLike from "../../../components/@enhancers/likes/toggle";
 
-import { nav as navActions, modal } from "../../../data/store";
-
 import Layout from "./Layout";
 import Join from "./Join";
 
@@ -32,12 +30,6 @@ class TemplateWithoutData extends Component {
     if (this.headerAction) {
       this.headerAction({ title: "Group Profile" });
     }
-    if (process.env.WEB) return;
-    this.props.dispatch(navActions.setLevel("CONTENT"));
-    this.props.dispatch(navActions.setAction("CONTENT", {
-      id: 2,
-      action: this.props.onLike,
-    }));
   }
 
   componentWillUnmount() {

--- a/imports/pages/music/Album.js
+++ b/imports/pages/music/Album.js
@@ -8,7 +8,7 @@ import Meta from "../../components/shared/meta";
 // loading state
 import Loading from "../../components/@primitives/UI/loading";
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import Likeable from "../../deprecated/mixins/mixins.Likeable";
+import CanLike from "../../components/@enhancers/can-like";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 // action helpers
@@ -42,7 +42,7 @@ class MusicAlbumWithoutData extends Component {
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
-      action: this.likeableAction,
+      action: this.props.onLike,
     }));
   }
 
@@ -224,11 +224,9 @@ const withAlbum = graphql(ALBUM_QUERY, {
 
 export default connect()(
   withAlbum(
-    ReactMixin.decorate(Likeable)(
-      ReactMixin.decorate(Shareable)(
-        ReactMixin.decorate(Headerable)(
-          MusicAlbumWithoutData
-        )
+    ReactMixin.decorate(Shareable)(
+      ReactMixin.decorate(Headerable)(
+        CanLike(MusicAlbumWithoutData)
       )
     )
   )

--- a/imports/pages/music/Album.js
+++ b/imports/pages/music/Album.js
@@ -13,7 +13,6 @@ import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 // action helpers
 import {
-  nav as navActions,
   audio as audioActions,
 } from "../../data/store";
 
@@ -29,7 +28,6 @@ class MusicAlbumWithoutData extends Component {
     ]).isRequired,
     modalVisible: PropTypes.bool,
     albumArtist: PropTypes.string,
-    onLike: PropTypes.function,
   }
 
   state = {

--- a/imports/pages/music/Album.js
+++ b/imports/pages/music/Album.js
@@ -226,7 +226,7 @@ export default connect()(
   withAlbum(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike(MusicAlbumWithoutData)
+        CanLike((props) => props.album.loading ? null : props.album.content.id)(MusicAlbumWithoutData)
       )
     )
   )

--- a/imports/pages/music/Album.js
+++ b/imports/pages/music/Album.js
@@ -8,7 +8,7 @@ import Meta from "../../components/shared/meta";
 // loading state
 import Loading from "../../components/@primitives/UI/loading";
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import CanLike from "../../components/@enhancers/can-like";
+import canLike from "../../components/@enhancers/likes/toggle";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 // action helpers
@@ -226,7 +226,7 @@ export default connect()(
   withAlbum(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike((props) => props.album.loading ? null : props.album.content.id)(MusicAlbumWithoutData)
+        canLike((props) => props.album.loading ? null : props.album.content.id)(MusicAlbumWithoutData)
       )
     )
   )

--- a/imports/pages/music/Album.js
+++ b/imports/pages/music/Album.js
@@ -29,6 +29,7 @@ class MusicAlbumWithoutData extends Component {
     ]).isRequired,
     modalVisible: PropTypes.bool,
     albumArtist: PropTypes.string,
+    onLike: PropTypes.function,
   }
 
   state = {
@@ -226,7 +227,9 @@ export default connect()(
   withAlbum(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        canLike((props) => props.album.loading ? null : props.album.content.id)(MusicAlbumWithoutData)
+        canLike(
+          (props) => (props.album.loading ? null : props.album.content.id)
+        )(MusicAlbumWithoutData)
       )
     )
   )

--- a/imports/pages/music/Album.js
+++ b/imports/pages/music/Album.js
@@ -38,17 +38,7 @@ class MusicAlbumWithoutData extends Component {
     force: false,
   }
 
-  componentWillMount() {
-    if (process.env.WEB) return;
-    this.props.dispatch(navActions.setLevel("CONTENT"));
-    this.props.dispatch(navActions.setAction("CONTENT", {
-      id: 2,
-      action: this.props.onLike,
-    }));
-  }
-
   componentWillUnmount() {
-    this.props.dispatch(navActions.setLevel("TOP"));
     this.props.dispatch(audioActions.dock());
   }
 

--- a/imports/pages/music/__tests__/Album.js
+++ b/imports/pages/music/__tests__/Album.js
@@ -1,7 +1,6 @@
 import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
 import {
-  nav as navActions,
   audio as audioActions,
 } from "../../../data/store";
 import {
@@ -13,10 +12,6 @@ jest.mock("../../../deprecated/mixins/mixins.Header", () => {});
 jest.mock("../../../deprecated/mixins/mixins.Likeable", () => {});
 jest.mock("../../../deprecated/mixins/mixins.Shareable", () => {});
 jest.mock("../../../data/store", () => ({
-  nav: {
-    setLevel: jest.fn(),
-    setAction: jest.fn(),
-  },
   audio: {
     dock: jest.fn(),
   },
@@ -91,34 +86,6 @@ it("adjust style if modal visible", () => {
 
 it("parses query correctly", () => {
   expect(ALBUM_QUERY).toMatchSnapshot();
-});
-
-it("updates nav on mount", () => {
-  const mockDispatch = jest.fn();
-  navActions.setLevel = jest.fn();
-  navActions.setAction = jest.fn();
-  const wrapper = shallow(generateComponent({
-    dispatch: mockDispatch,
-  }));
-  expect(mockDispatch).toHaveBeenCalledTimes(2);
-  expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  expect(navActions.setAction).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel.mock.calls[0][0]).toBe("CONTENT");
-});
-
-it("updates nav on unmount", () => {
-  const mockDispatch = jest.fn();
-  navActions.setLevel = jest.fn();
-  audioActions.dock = jest.fn();
-  const wrapper = shallow(generateComponent({
-    dispatch: mockDispatch,
-  }));
-  wrapper.unmount();
-  expect(mockDispatch).toHaveBeenCalledTimes(4);
-  expect(navActions.setLevel).toHaveBeenCalledTimes(2);
-  expect(navActions.setLevel).toHaveBeenCalledWith("TOP");
-  expect(audioActions.dock).toHaveBeenCalledTimes(1);
 });
 
 it("shuffle toggles repeatPattern between shuffle and next", () => {

--- a/imports/pages/news/Single.js
+++ b/imports/pages/news/Single.js
@@ -1,4 +1,4 @@
-import { Component, PropTypes } from "react";
+import { PropTypes } from "react";
 import ReactMixin from "react-mixin";
 import { graphql } from "react-apollo";
 import { connect } from "react-redux";
@@ -14,30 +14,27 @@ import Shareable from "../../deprecated/mixins/mixins.Shareable";
 // import content component
 import StoriesContent from "./Content";
 
-class StoriesSingleWithoutData extends Component {
+const StoriesSingleWithoutData = (props) => {
+  const { content } = props.news;
 
-  static propTypes = {
-    news: PropTypes.object,
-  }
-
-  render() {
-    const { content } = this.props.news;
-
-    if (!content) {
-      // loading
-      return (
-        <div className="locked-ends locked-sides floating">
-          <div className="floating__item">
-            <Loading />
-          </div>
+  if (!content) {
+    // loading
+    return (
+      <div className="locked-ends locked-sides floating">
+        <div className="floating__item">
+          <Loading />
         </div>
-      );
-    }
-
-    const story = content;
-    return <StoriesContent story={story} />;
+      </div>
+    );
   }
-}
+
+  const story = content;
+  return <StoriesContent story={story} />;
+};
+
+StoriesSingleWithoutData.propTypes = {
+  news: PropTypes.object,
+};
 
 const GET_NEWS_QUERY = gql`
   query getNews($id: ID!) {

--- a/imports/pages/news/Single.js
+++ b/imports/pages/news/Single.js
@@ -6,7 +6,6 @@ import gql from "graphql-tag";
 
 // loading state
 import Loading from "../../components/@primitives/UI/loading";
-import { nav as navActions } from "../../data/store";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
 import canLike from "../../components/@enhancers/likes/toggle";
@@ -21,15 +20,6 @@ class StoriesSingleWithoutData extends Component {
     dispatch: PropTypes.func.isRequired,
     news: PropTypes.object,
     onLike: PropTypes.function,
-  }
-
-  componentWillMount() {
-    if (process.env.WEB) return;
-    this.props.dispatch(navActions.setLevel("CONTENT"));
-    this.props.dispatch(navActions.setAction("CONTENT", {
-      id: 2,
-      action: this.props.onLike,
-    }));
   }
 
   render() {

--- a/imports/pages/news/Single.js
+++ b/imports/pages/news/Single.js
@@ -1,4 +1,7 @@
-import { PropTypes } from "react";
+
+// @flow
+// ignore this until we can remove it entirely
+// $FlowMeteor
 import ReactMixin from "react-mixin";
 import { graphql } from "react-apollo";
 import { connect } from "react-redux";
@@ -14,7 +17,11 @@ import Shareable from "../../deprecated/mixins/mixins.Shareable";
 // import content component
 import StoriesContent from "./Content";
 
-const StoriesSingleWithoutData = (props) => {
+type IStoriesSingleWithoutData = {
+  news: Object,
+};
+
+const StoriesSingleWithoutData = (props: IStoriesSingleWithoutData) => {
   const { content } = props.news;
 
   if (!content) {
@@ -30,10 +37,6 @@ const StoriesSingleWithoutData = (props) => {
 
   const story = content;
   return <StoriesContent story={story} />;
-};
-
-StoriesSingleWithoutData.propTypes = {
-  news: PropTypes.object,
 };
 
 const GET_NEWS_QUERY = gql`

--- a/imports/pages/news/Single.js
+++ b/imports/pages/news/Single.js
@@ -92,7 +92,7 @@ export default connect()(
   withNews(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike(StoriesSingleWithoutData)
+        CanLike((props) => props.news.loading ? null : props.news.content.id)(StoriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/news/Single.js
+++ b/imports/pages/news/Single.js
@@ -17,9 +17,7 @@ import StoriesContent from "./Content";
 class StoriesSingleWithoutData extends Component {
 
   static propTypes = {
-    dispatch: PropTypes.func.isRequired,
     news: PropTypes.object,
-    onLike: PropTypes.function,
   }
 
   render() {

--- a/imports/pages/news/Single.js
+++ b/imports/pages/news/Single.js
@@ -20,6 +20,7 @@ class StoriesSingleWithoutData extends Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     news: PropTypes.object,
+    onLike: PropTypes.function,
   }
 
   componentWillMount() {
@@ -92,7 +93,9 @@ export default connect()(
   withNews(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        canLike((props) => props.news.loading ? null : props.news.content.id)(StoriesSingleWithoutData)
+        canLike(
+          (props) => (props.news.loading ? null : props.news.content.id)
+        )(StoriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/news/Single.js
+++ b/imports/pages/news/Single.js
@@ -9,7 +9,7 @@ import Loading from "../../components/@primitives/UI/loading";
 import { nav as navActions } from "../../data/store";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import CanLike from "../../components/@enhancers/can-like";
+import canLike from "../../components/@enhancers/likes/toggle";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 // import content component
@@ -92,7 +92,7 @@ export default connect()(
   withNews(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike((props) => props.news.loading ? null : props.news.content.id)(StoriesSingleWithoutData)
+        canLike((props) => props.news.loading ? null : props.news.content.id)(StoriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/news/Single.js
+++ b/imports/pages/news/Single.js
@@ -9,7 +9,7 @@ import Loading from "../../components/@primitives/UI/loading";
 import { nav as navActions } from "../../data/store";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import Likeable from "../../deprecated/mixins/mixins.Likeable";
+import CanLike from "../../components/@enhancers/can-like";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 // import content component
@@ -27,7 +27,7 @@ class StoriesSingleWithoutData extends Component {
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
-      action: this.likeableAction,
+      action: this.props.onLike,
     }));
   }
 
@@ -90,11 +90,9 @@ const withNews = graphql(GET_NEWS_QUERY, {
 
 export default connect()(
   withNews(
-    ReactMixin.decorate(Likeable)(
-      ReactMixin.decorate(Shareable)(
-        ReactMixin.decorate(Headerable)(
-          StoriesSingleWithoutData
-        )
+    ReactMixin.decorate(Shareable)(
+      ReactMixin.decorate(Headerable)(
+        CanLike(StoriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/news/__tests__/Single.js
+++ b/imports/pages/news/__tests__/Single.js
@@ -48,18 +48,3 @@ it("renders loading if no content", () => {
 it("parses query correctly", () => {
   expect(GET_NEWS_QUERY).toMatchSnapshot();
 });
-
-it("updates nav on mount", () => {
-  const mockDispatch = jest.fn();
-  navActions.setLevel = jest.fn();
-  navActions.setAction = jest.fn();
-  const wrapper = shallow(generateComponent({
-    dispatch: mockDispatch,
-  }));
-  expect(mockDispatch).toHaveBeenCalledTimes(2);
-  expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  expect(navActions.setAction).toHaveBeenCalledTimes(1);
-  expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
-  expect(navActions.setAction.mock.calls[0][1]).toMatchSnapshot();
-});

--- a/imports/pages/news/__tests__/__snapshots__/Single.js.snap
+++ b/imports/pages/news/__tests__/__snapshots__/Single.js.snap
@@ -384,10 +384,3 @@ exports[`test renders with props 1`] = `
 <StoriesContent
   story={Object {}} />
 `;
-
-exports[`test updates nav on mount 1`] = `
-Object {
-  "action": undefined,
-  "id": 2,
-}
-`;

--- a/imports/pages/series/Single.js
+++ b/imports/pages/series/Single.js
@@ -30,7 +30,6 @@ class SeriesSingleWithoutData extends Component {
     dispatch: PropTypes.func.isRequired,
     series: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
-    onLike: PropTypes.function,
   }
 
   componentWillMount() {

--- a/imports/pages/series/Single.js
+++ b/imports/pages/series/Single.js
@@ -12,7 +12,7 @@ import { nav as navActions } from "../../data/store";
 import headerActions from "../../data/store/header";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import CanLike from "../../components/@enhancers/can-like";
+import canLike from "../../components/@enhancers/likes/toggle";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 
@@ -165,7 +165,7 @@ export default connect()(
   withSingleSeries(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike((props) => props.series.loading ? null : props.series.content.id)(SeriesSingleWithoutData)
+        canLike((props) => props.series.loading ? null : props.series.content.id)(SeriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/series/Single.js
+++ b/imports/pages/series/Single.js
@@ -165,7 +165,7 @@ export default connect()(
   withSingleSeries(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike(SeriesSingleWithoutData)
+        CanLike((props) => props.series.loading ? null : props.series.content.id)(SeriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/series/Single.js
+++ b/imports/pages/series/Single.js
@@ -8,7 +8,6 @@ import Meta from "../../components/shared/meta";
 
 // loading state
 import Loading from "../../components/@primitives/UI/loading";
-import { nav as navActions } from "../../data/store";
 import headerActions from "../../data/store/header";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
@@ -39,12 +38,6 @@ class SeriesSingleWithoutData extends Component {
 
     // needed for cached data
     this.handleHeaderStyle(this.props);
-
-    this.props.dispatch(navActions.setLevel("CONTENT"));
-    this.props.dispatch(navActions.setAction("CONTENT", {
-      id: 2,
-      action: this.props.onLike,
-    }));
   }
 
   componentWillUpdate(nextProps) {

--- a/imports/pages/series/Single.js
+++ b/imports/pages/series/Single.js
@@ -12,7 +12,7 @@ import { nav as navActions } from "../../data/store";
 import headerActions from "../../data/store/header";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import Likeable from "../../deprecated/mixins/mixins.Likeable";
+import CanLike from "../../components/@enhancers/can-like";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 
@@ -42,7 +42,7 @@ class SeriesSingleWithoutData extends Component {
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
-      action: this.likeableAction,
+      action: this.props.onLike,
     }));
   }
 
@@ -163,11 +163,9 @@ const withSingleSeries = graphql(SERIES_SINGLE_QUERY, {
 
 export default connect()(
   withSingleSeries(
-    ReactMixin.decorate(Likeable)(
-      ReactMixin.decorate(Shareable)(
-        ReactMixin.decorate(Headerable)(
-          SeriesSingleWithoutData
-        )
+    ReactMixin.decorate(Shareable)(
+      ReactMixin.decorate(Headerable)(
+        CanLike(SeriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/series/Single.js
+++ b/imports/pages/series/Single.js
@@ -31,6 +31,7 @@ class SeriesSingleWithoutData extends Component {
     dispatch: PropTypes.func.isRequired,
     series: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
+    onLike: PropTypes.function,
   }
 
   componentWillMount() {
@@ -165,7 +166,9 @@ export default connect()(
   withSingleSeries(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        canLike((props) => props.series.loading ? null : props.series.content.id)(SeriesSingleWithoutData)
+        canLike(
+          (props) => (props.series.loading ? null : props.series.content.id)
+        )(SeriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/series/SingleVideo.js
+++ b/imports/pages/series/SingleVideo.js
@@ -215,7 +215,7 @@ export default connect(mapStateToProps)(
     withSeries(
       ReactMixin.decorate(Shareable)(
         ReactMixin.decorate(Headerable)(
-          CanLike(SeriesSingleVideoWithoutData)
+          CanLike((props) => props.series.loading ? null : props.series.content.id)(SeriesSingleVideoWithoutData)
         )
       )
     )

--- a/imports/pages/series/SingleVideo.js
+++ b/imports/pages/series/SingleVideo.js
@@ -7,7 +7,6 @@ import gql from "graphql-tag";
 
 import Loading from "../../components/@primitives/UI/loading";
 import {
-  nav as navActions,
   audio as audioActions,
   header as headerActions,
 } from "../../data/store";
@@ -40,12 +39,6 @@ class SeriesSingleVideoWithoutData extends Component {
 
     // needed for client cache
     this.handleHeader(this.props);
-
-    this.props.dispatch(navActions.setLevel("CONTENT"));
-    this.props.dispatch(navActions.setAction("CONTENT", {
-      id: 2,
-      action: this.props.onLike,
-    }));
   }
 
   componentWillUpdate(nextProps) {
@@ -217,7 +210,7 @@ export default connect(mapStateToProps)(
       ReactMixin.decorate(Shareable)(
         ReactMixin.decorate(Headerable)(
           canLike(
-            (props) => (props.series.loading ? null : props.series.content.id)
+            (props) => (props.currentSermon.loading ? null : props.currentSermon.content.entryId)
           )(SeriesSingleVideoWithoutData)
         )
       )

--- a/imports/pages/series/SingleVideo.js
+++ b/imports/pages/series/SingleVideo.js
@@ -32,6 +32,7 @@ class SeriesSingleVideoWithoutData extends Component {
     currentSermon: PropTypes.object.isRequired,
     series: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
+    onLike: PropTypes.function,
   }
 
   componentWillMount() {
@@ -215,7 +216,9 @@ export default connect(mapStateToProps)(
     withSeries(
       ReactMixin.decorate(Shareable)(
         ReactMixin.decorate(Headerable)(
-          canLike((props) => props.series.loading ? null : props.series.content.id)(SeriesSingleVideoWithoutData)
+          canLike(
+            (props) => (props.series.loading ? null : props.series.content.id)
+          )(SeriesSingleVideoWithoutData)
         )
       )
     )

--- a/imports/pages/series/SingleVideo.js
+++ b/imports/pages/series/SingleVideo.js
@@ -13,7 +13,7 @@ import {
 } from "../../data/store";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import Likeable from "../../deprecated/mixins/mixins.Likeable";
+import CanLike from "../../components/@enhancers/can-like";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 import time from "../../util/time";
@@ -43,7 +43,7 @@ class SeriesSingleVideoWithoutData extends Component {
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
-      action: this.likeableAction,
+      action: this.props.onLike,
     }));
   }
 
@@ -213,11 +213,9 @@ const mapStateToProps = (state) => ({ live: state.live });
 export default connect(mapStateToProps)(
   withCurrentSermon(
     withSeries(
-      ReactMixin.decorate(Likeable)(
-        ReactMixin.decorate(Shareable)(
-          ReactMixin.decorate(Headerable)(
-            SeriesSingleVideoWithoutData
-          )
+      ReactMixin.decorate(Shareable)(
+        ReactMixin.decorate(Headerable)(
+          CanLike(SeriesSingleVideoWithoutData)
         )
       )
     )

--- a/imports/pages/series/SingleVideo.js
+++ b/imports/pages/series/SingleVideo.js
@@ -31,7 +31,6 @@ class SeriesSingleVideoWithoutData extends Component {
     currentSermon: PropTypes.object.isRequired,
     series: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
-    onLike: PropTypes.function,
   }
 
   componentWillMount() {

--- a/imports/pages/series/SingleVideo.js
+++ b/imports/pages/series/SingleVideo.js
@@ -13,7 +13,7 @@ import {
 } from "../../data/store";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import CanLike from "../../components/@enhancers/can-like";
+import canLike from "../../components/@enhancers/likes/toggle";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 import time from "../../util/time";
@@ -215,7 +215,7 @@ export default connect(mapStateToProps)(
     withSeries(
       ReactMixin.decorate(Shareable)(
         ReactMixin.decorate(Headerable)(
-          CanLike((props) => props.series.loading ? null : props.series.content.id)(SeriesSingleVideoWithoutData)
+          canLike((props) => props.series.loading ? null : props.series.content.id)(SeriesSingleVideoWithoutData)
         )
       )
     )

--- a/imports/pages/series/__tests__/Single.js
+++ b/imports/pages/series/__tests__/Single.js
@@ -1,6 +1,5 @@
 import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
-import { nav as navActions } from "../../../data/store";
 import headerActions from "../../../data/store/header";
 import {
   SeriesSingleWithoutData as SeriesSingle,
@@ -12,12 +11,6 @@ jest.mock("../../../deprecated/mixins/mixins.Likeable", () => {});
 jest.mock("../../../deprecated/mixins/mixins.Shareable", () => {});
 jest.mock("../../../data/store/header", () => ({
   set: jest.fn(),
-}));
-jest.mock("../../../data/store", () => ({
-  nav: {
-    setLevel: jest.fn(),
-    setAction: jest.fn(),
-  },
 }));
 
 const defaultProps = {
@@ -72,18 +65,6 @@ it("renders loading", () => {
 
 it("parses query", () => {
   expect(SERIES_SINGLE_QUERY).toMatchSnapshot();
-});
-
-it("updates nav on mount", () => {
-  const mockDispatch = jest.fn();
-  navActions.setLevel = jest.fn();
-  navActions.setActions = jest.fn();
-  const wrapper = shallow(generateComponent({
-    dispatch: mockDispatch,
-  }));
-  expect(mockDispatch).toHaveBeenCalledTimes(3);
-  expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
 });
 
 it("handleHeaderStyle updates the header", () => {

--- a/imports/pages/series/__tests__/SingleVideo.js
+++ b/imports/pages/series/__tests__/SingleVideo.js
@@ -1,7 +1,6 @@
 import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
 import {
-  nav as navActions,
   audio as audioActions,
   header as headerActions,
 } from "../../../data/store";
@@ -15,10 +14,6 @@ jest.mock("../../../deprecated/mixins/mixins.Header", () => {});
 jest.mock("../../../deprecated/mixins/mixins.Likeable", () => {});
 jest.mock("../../../deprecated/mixins/mixins.Shareable", () => {});
 jest.mock("../../../data/store", () => ({
-  nav: {
-    setLevel: jest.fn(),
-    setAction: jest.fn(),
-  },
   audio: {
     setPlaying: jest.fn(),
   },
@@ -101,21 +96,6 @@ it("parses series query", () => {
 
 it("parses sermon query", () => {
   expect(CURRENT_SERMON_QUERY).toMatchSnapshot();
-});
-
-it("updates nav on mount", () => {
-  const mockDispatch = jest.fn();
-  navActions.setLevel = jest.fn();
-  navActions.setAction = jest.fn();
-  const wrapper = shallow(generateComponent({
-    dispatch: mockDispatch,
-  }));
-  // from handleHeader as well
-  expect(mockDispatch).toHaveBeenCalledTimes(3);
-  expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  expect(navActions.setAction).toHaveBeenCalledTimes(1);
-  expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
 });
 
 it("handleHeader updates the header", () => {

--- a/imports/pages/stories/Single.js
+++ b/imports/pages/stories/Single.js
@@ -9,7 +9,7 @@ import Loading from "../../components/@primitives/UI/loading";
 import { nav as navActions } from "../../data/store";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import CanLike from "../../components/@enhancers/can-like";
+import canLike from "../../components/@enhancers/likes/toggle";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 // import content component
@@ -92,7 +92,7 @@ export default connect()(
   withStory(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike((props) => props.story.loading ? null : props.story.content.id)(StoriesSingleWithoutData)
+        canLike((props) => props.story.loading ? null : props.story.content.id)(StoriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/stories/Single.js
+++ b/imports/pages/stories/Single.js
@@ -9,7 +9,7 @@ import Loading from "../../components/@primitives/UI/loading";
 import { nav as navActions } from "../../data/store";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import Likeable from "../../deprecated/mixins/mixins.Likeable";
+import CanLike from "../../components/@enhancers/can-like";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 // import content component
@@ -27,7 +27,7 @@ class StoriesSingleWithoutData extends Component {
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
-      action: this.likeableAction,
+      action: this.props.onLike,
     }));
   }
 
@@ -90,11 +90,9 @@ const withStory = graphql(GET_STORY_QUERY, {
 
 export default connect()(
   withStory(
-    ReactMixin.decorate(Likeable)(
-      ReactMixin.decorate(Shareable)(
-        ReactMixin.decorate(Headerable)(
-          StoriesSingleWithoutData
-        )
+    ReactMixin.decorate(Shareable)(
+      ReactMixin.decorate(Headerable)(
+        CanLike(StoriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/stories/Single.js
+++ b/imports/pages/stories/Single.js
@@ -20,6 +20,7 @@ class StoriesSingleWithoutData extends Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     story: PropTypes.object,
+    onLike: PropTypes.function,
   }
 
   componentWillMount() {
@@ -92,7 +93,9 @@ export default connect()(
   withStory(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        canLike((props) => props.story.loading ? null : props.story.content.id)(StoriesSingleWithoutData)
+        canLike(
+          (props) => (props.story.loading ? null : props.story.content.id)
+        )(StoriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/stories/Single.js
+++ b/imports/pages/stories/Single.js
@@ -17,9 +17,7 @@ import StoriesContent from "./Content";
 class StoriesSingleWithoutData extends Component {
 
   static propTypes = {
-    dispatch: PropTypes.func.isRequired,
     story: PropTypes.object,
-    onLike: PropTypes.function,
   }
 
   render() {

--- a/imports/pages/stories/Single.js
+++ b/imports/pages/stories/Single.js
@@ -6,7 +6,6 @@ import gql from "graphql-tag";
 
 // loading state
 import Loading from "../../components/@primitives/UI/loading";
-import { nav as navActions } from "../../data/store";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
 import canLike from "../../components/@enhancers/likes/toggle";
@@ -21,15 +20,6 @@ class StoriesSingleWithoutData extends Component {
     dispatch: PropTypes.func.isRequired,
     story: PropTypes.object,
     onLike: PropTypes.function,
-  }
-
-  componentWillMount() {
-    if (process.env.WEB) return;
-    this.props.dispatch(navActions.setLevel("CONTENT"));
-    this.props.dispatch(navActions.setAction("CONTENT", {
-      id: 2,
-      action: this.props.onLike,
-    }));
   }
 
   render() {

--- a/imports/pages/stories/Single.js
+++ b/imports/pages/stories/Single.js
@@ -1,4 +1,4 @@
-import { Component, PropTypes } from "react";
+import { PropTypes } from "react";
 import ReactMixin from "react-mixin";
 import { graphql } from "react-apollo";
 import { connect } from "react-redux";
@@ -14,30 +14,27 @@ import Shareable from "../../deprecated/mixins/mixins.Shareable";
 // import content component
 import StoriesContent from "./Content";
 
-class StoriesSingleWithoutData extends Component {
+const StoriesSingleWithoutData = (props) => {
+  const { content } = props.story;
 
-  static propTypes = {
-    story: PropTypes.object,
-  }
-
-  render() {
-    const { content } = this.props.story;
-
-    if (!content) {
-      // loading
-      return (
-        <div className="locked-ends locked-sides floating">
-          <div className="floating__item">
-            <Loading />
-          </div>
+  if (!content) {
+    // loading
+    return (
+      <div className="locked-ends locked-sides floating">
+        <div className="floating__item">
+          <Loading />
         </div>
-      );
-    }
-
-    const story = content;
-    return <StoriesContent story={story} />;
+      </div>
+    );
   }
-}
+
+  const story = content;
+  return <StoriesContent story={story} />;
+};
+
+StoriesSingleWithoutData.propTypes = {
+  story: PropTypes.object,
+};
 
 const GET_STORY_QUERY = gql`
   query getStory($id: ID!) {

--- a/imports/pages/stories/Single.js
+++ b/imports/pages/stories/Single.js
@@ -92,7 +92,7 @@ export default connect()(
   withStory(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike(StoriesSingleWithoutData)
+        CanLike((props) => props.story.loading ? null : props.story.content.id)(StoriesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/stories/Single.js
+++ b/imports/pages/stories/Single.js
@@ -1,4 +1,7 @@
-import { PropTypes } from "react";
+
+// @flow
+// ignore until we can remove this entirely
+// $FlowMeteor
 import ReactMixin from "react-mixin";
 import { graphql } from "react-apollo";
 import { connect } from "react-redux";
@@ -14,7 +17,11 @@ import Shareable from "../../deprecated/mixins/mixins.Shareable";
 // import content component
 import StoriesContent from "./Content";
 
-const StoriesSingleWithoutData = (props) => {
+type IStoriesSingleWithouData = {
+  story: Object,
+};
+
+const StoriesSingleWithoutData = (props: IStoriesSingleWithouData) => {
   const { content } = props.story;
 
   if (!content) {
@@ -30,10 +37,6 @@ const StoriesSingleWithoutData = (props) => {
 
   const story = content;
   return <StoriesContent story={story} />;
-};
-
-StoriesSingleWithoutData.propTypes = {
-  story: PropTypes.object,
 };
 
 const GET_STORY_QUERY = gql`

--- a/imports/pages/stories/__tests__/Single.js
+++ b/imports/pages/stories/__tests__/Single.js
@@ -1,6 +1,5 @@
 import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
-import { nav as navActions } from "../../../data/store";
 import {
   StoriesSingleWithoutData as StoriesSingle,
   GET_STORY_QUERY,
@@ -9,12 +8,6 @@ import {
 jest.mock("../../../deprecated/mixins/mixins.Header", () => {});
 jest.mock("../../../deprecated/mixins/mixins.Likeable", () => {});
 jest.mock("../../../deprecated/mixins/mixins.Shareable", () => {});
-jest.mock("../../../data/store", () => ({
-  nav: {
-    setLevel: jest.fn(),
-    setAction: jest.fn(),
-  },
-}));
 
 const defaultProps = {
   dispatch: jest.fn(),
@@ -47,19 +40,4 @@ it("renders loading if no content", () => {
 
 it("parses query correctly", () => {
   expect(GET_STORY_QUERY).toMatchSnapshot();
-});
-
-it("updates nav on mount", () => {
-  const mockDispatch = jest.fn();
-  navActions.setLevel = jest.fn();
-  navActions.setAction = jest.fn();
-  const wrapper = shallow(generateComponent({
-    dispatch: mockDispatch,
-  }));
-  expect(mockDispatch).toHaveBeenCalledTimes(2);
-  expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  expect(navActions.setAction).toHaveBeenCalledTimes(1);
-  expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
-  expect(navActions.setAction.mock.calls[0][1]).toMatchSnapshot();
 });

--- a/imports/pages/stories/__tests__/__snapshots__/Single.js.snap
+++ b/imports/pages/stories/__tests__/__snapshots__/Single.js.snap
@@ -384,10 +384,3 @@ exports[`test renders with props 1`] = `
 <StoriesContent
   story={Object {}} />
 `;
-
-exports[`test updates nav on mount 1`] = `
-Object {
-  "action": undefined,
-  "id": 2,
-}
-`;

--- a/imports/pages/studies/Single.js
+++ b/imports/pages/studies/Single.js
@@ -12,7 +12,7 @@ import { nav as navActions } from "../../data/store";
 import headerActions from "../../data/store/header";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import CanLike from "../../components/@enhancers/can-like";
+import canLike from "../../components/@enhancers/likes/toggle";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 
@@ -183,7 +183,7 @@ export default connect()(
   withStudySingle(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike((props) => props.study.loading ? null : props.study.content.id)(StudiesSingleWithoutData)
+        canLike((props) => props.study.loading ? null : props.study.content.id)(StudiesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/studies/Single.js
+++ b/imports/pages/studies/Single.js
@@ -34,6 +34,7 @@ class StudiesSingleWithoutData extends Component {
     dispatch: PropTypes.func.isRequired,
     study: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
+    onLike: PropTypes.function,
   }
 
   componentWillMount() {
@@ -183,7 +184,9 @@ export default connect()(
   withStudySingle(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        canLike((props) => props.study.loading ? null : props.study.content.id)(StudiesSingleWithoutData)
+        canLike(
+          (props) => (props.study.loading ? null : props.study.content.id)
+        )(StudiesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/studies/Single.js
+++ b/imports/pages/studies/Single.js
@@ -8,7 +8,6 @@ import Meta from "../../components/shared/meta";
 
 // loading state
 import Loading from "../../components/@primitives/UI/loading";
-import { nav as navActions } from "../../data/store";
 import headerActions from "../../data/store/header";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
@@ -42,12 +41,6 @@ class StudiesSingleWithoutData extends Component {
 
     // needed for cached data
     this.handleHeaderStyle(this.props);
-
-    this.props.dispatch(navActions.setLevel("CONTENT"));
-    this.props.dispatch(navActions.setAction("CONTENT", {
-      id: 2,
-      action: this.props.onLike,
-    }));
   }
 
   componentWillUpdate(nextProps) {

--- a/imports/pages/studies/Single.js
+++ b/imports/pages/studies/Single.js
@@ -183,7 +183,7 @@ export default connect()(
   withStudySingle(
     ReactMixin.decorate(Shareable)(
       ReactMixin.decorate(Headerable)(
-        CanLike(StudiesSingleWithoutData)
+        CanLike((props) => props.study.loading ? null : props.study.content.id)(StudiesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/studies/Single.js
+++ b/imports/pages/studies/Single.js
@@ -12,7 +12,7 @@ import { nav as navActions } from "../../data/store";
 import headerActions from "../../data/store/header";
 
 import Headerable from "../../deprecated/mixins/mixins.Header";
-import Likeable from "../../deprecated/mixins/mixins.Likeable";
+import CanLike from "../../components/@enhancers/can-like";
 import Shareable from "../../deprecated/mixins/mixins.Shareable";
 
 
@@ -45,7 +45,7 @@ class StudiesSingleWithoutData extends Component {
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
-      action: this.likeableAction,
+      action: this.props.onLike,
     }));
   }
 
@@ -181,11 +181,9 @@ const withStudySingle = graphql(STUDY_SINGLE_QUERY, {
 
 export default connect()(
   withStudySingle(
-    ReactMixin.decorate(Likeable)(
-      ReactMixin.decorate(Shareable)(
-        ReactMixin.decorate(Headerable)(
-          StudiesSingleWithoutData
-        )
+    ReactMixin.decorate(Shareable)(
+      ReactMixin.decorate(Headerable)(
+        CanLike(StudiesSingleWithoutData)
       )
     )
   )

--- a/imports/pages/studies/Single.js
+++ b/imports/pages/studies/Single.js
@@ -33,7 +33,6 @@ class StudiesSingleWithoutData extends Component {
     dispatch: PropTypes.func.isRequired,
     study: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
-    onLike: PropTypes.function,
   }
 
   componentWillMount() {

--- a/imports/pages/studies/__tests__/Single.js
+++ b/imports/pages/studies/__tests__/Single.js
@@ -4,9 +4,6 @@ import { shallow, mount } from "enzyme";
 import { reset, startBuffering } from "aphrodite/lib/inject";
 
 import { StudiesSingleWithoutData } from "../Single";
-import {
-  nav as navActions,
-} from "../../../data/store";
 import headerActions from "../../../data/store/header";
 
 jest.mock("../../../deprecated/database/collections/likes", () => {});
@@ -20,13 +17,6 @@ jest.mock("../Hero");
 
 jest.mock("../../../data/store/header", () => ({
   set: jest.fn(),
-}));
-
-jest.mock("../../../data/store", () => ({
-  nav: {
-    setLevel: jest.fn(),
-    setAction: jest.fn(),
-  },
 }));
 
 const defaultProps = {
@@ -105,19 +95,12 @@ it("renders studies content", () => {
 
 it("dispatches store on mount", () => {
   const mockDispatch = jest.fn();
-
-  navActions.setLevel = jest.fn();
-  navActions.setAction = jest.fn();
   headerActions.set = jest.fn();
 
   const wrapper = shallow(generateComponent({
     dispatch: mockDispatch,
   }));
 
-  expect(mockDispatch).toHaveBeenCalledTimes(3);
-  expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  expect(navActions.setAction).toHaveBeenCalledTimes(1);
-  expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
+  expect(mockDispatch).toHaveBeenCalledTimes(1);
   expect(headerActions.set).toHaveBeenCalledTimes(1);
 });

--- a/imports/pages/studies/entry/__tests__/index.js
+++ b/imports/pages/studies/entry/__tests__/index.js
@@ -9,7 +9,6 @@ import {
 } from "../index";
 
 import {
-  nav as navActions,
   header as headerActions,
   live as liveActions,
 } from "../../../../data/store";
@@ -107,18 +106,18 @@ it("renders loading with no studyEntry", () => {
 it("dispatches to the store on mount", () => {
   const mockDispatch = jest.fn();
   liveActions.hide = jest.fn();
-  navActions.setLevel = jest.fn();
-  navActions.setAction = jest.fn();
+  // navActions.setLevel = jest.fn();
+  // navActions.setAction = jest.fn();
   headerActions.set = jest.fn();
   const wrapper = shallow(generateComponent({
     dispatch: mockDispatch,
   }));
-  expect(mockDispatch).toHaveBeenCalledTimes(3);
+  expect(mockDispatch).toHaveBeenCalledTimes(1);
   expect(liveActions.hide).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  expect(navActions.setAction).toHaveBeenCalledTimes(1);
-  expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
+  // expect(navActions.setLevel).toHaveBeenCalledTimes(1);
+  // expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
+  // expect(navActions.setAction).toHaveBeenCalledTimes(1);
+  // expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
 });
 
 xit("updates when nextState is different", () => {
@@ -240,6 +239,3 @@ xit("updates live bar with push if scripture", () => {
   expect(liveActions.float).toHaveBeenCalledTimes(1);
   expect(liveActions.show).toHaveBeenCalledTimes(1);
 });
-
-
-

--- a/imports/pages/studies/entry/__tests__/index.js
+++ b/imports/pages/studies/entry/__tests__/index.js
@@ -106,18 +106,12 @@ it("renders loading with no studyEntry", () => {
 it("dispatches to the store on mount", () => {
   const mockDispatch = jest.fn();
   liveActions.hide = jest.fn();
-  // navActions.setLevel = jest.fn();
-  // navActions.setAction = jest.fn();
   headerActions.set = jest.fn();
   const wrapper = shallow(generateComponent({
     dispatch: mockDispatch,
   }));
   expect(mockDispatch).toHaveBeenCalledTimes(1);
   expect(liveActions.hide).toHaveBeenCalledTimes(1);
-  // expect(navActions.setLevel).toHaveBeenCalledTimes(1);
-  // expect(navActions.setLevel).toHaveBeenCalledWith("CONTENT");
-  // expect(navActions.setAction).toHaveBeenCalledTimes(1);
-  // expect(navActions.setAction.mock.calls[0][0]).toBe("CONTENT");
 });
 
 xit("updates when nextState is different", () => {

--- a/imports/pages/studies/entry/index.js
+++ b/imports/pages/studies/entry/index.js
@@ -7,7 +7,7 @@ import gql from "graphql-tag";
 import Meta from "../../../components/shared/meta";
 import Loading from "../../../components/@primitives/UI/loading";
 
-import canLike from "../../components/@enhancers/likes/toggle";
+import canLike from "../../../components/@enhancers/likes/toggle";
 import Shareable from "../../../deprecated/mixins/mixins.Shareable";
 
 // import contentHelpers from "../../../util/content";

--- a/imports/pages/studies/entry/index.js
+++ b/imports/pages/studies/entry/index.js
@@ -313,7 +313,7 @@ export default connect(mapStateToProps)(
   withCurrentStudyEntry(
     withStudy(
       ReactMixin.decorate(Shareable)(
-        CanLike(StudyEntrySingle)
+        CanLike((props) => props.study.loading ? null : props.study.content.id)(StudyEntrySingle)
       )
     )
   )

--- a/imports/pages/studies/entry/index.js
+++ b/imports/pages/studies/entry/index.js
@@ -30,7 +30,6 @@ class StudyEntrySingle extends Component {
     studyEntry: PropTypes.object.isRequired,
     study: PropTypes.object.isRequired,
     params: PropTypes.object.isRequried,
-    onLike: PropTypes.function,
   }
 
   state = {};

--- a/imports/pages/studies/entry/index.js
+++ b/imports/pages/studies/entry/index.js
@@ -7,7 +7,7 @@ import gql from "graphql-tag";
 import Meta from "../../../components/shared/meta";
 import Loading from "../../../components/@primitives/UI/loading";
 
-import CanLike from "../../../components/@enhancers/can-like";
+import canLike from "../../components/@enhancers/likes/toggle";
 import Shareable from "../../../deprecated/mixins/mixins.Shareable";
 
 // import contentHelpers from "../../../util/content";
@@ -313,7 +313,7 @@ export default connect(mapStateToProps)(
   withCurrentStudyEntry(
     withStudy(
       ReactMixin.decorate(Shareable)(
-        CanLike((props) => props.study.loading ? null : props.study.content.id)(StudyEntrySingle)
+        canLike((props) => props.study.loading ? null : props.study.content.id)(StudyEntrySingle)
       )
     )
   )

--- a/imports/pages/studies/entry/index.js
+++ b/imports/pages/studies/entry/index.js
@@ -31,6 +31,7 @@ class StudyEntrySingle extends Component {
     studyEntry: PropTypes.object.isRequired,
     study: PropTypes.object.isRequired,
     params: PropTypes.object.isRequried,
+    onLike: PropTypes.function,
   }
 
   state = {};
@@ -313,7 +314,9 @@ export default connect(mapStateToProps)(
   withCurrentStudyEntry(
     withStudy(
       ReactMixin.decorate(Shareable)(
-        canLike((props) => props.study.loading ? null : props.study.content.id)(StudyEntrySingle)
+        canLike(
+          (props) => (props.study.loading ? null : props.study.content.id)
+        )(StudyEntrySingle)
       )
     )
   )

--- a/imports/pages/studies/entry/index.js
+++ b/imports/pages/studies/entry/index.js
@@ -14,7 +14,6 @@ import Shareable from "../../../deprecated/mixins/mixins.Shareable";
 import collections from "../../../util/collections";
 
 import {
-  nav as navActions,
   header as headerActions,
   live as liveActions,
 } from "../../../data/store";
@@ -49,12 +48,6 @@ class StudyEntrySingle extends Component {
     this.props.dispatch(liveActions.hide());
     // for cached data
     this.handleLiveBar(this.props, this.state);
-
-    this.props.dispatch(navActions.setLevel("CONTENT"));
-    this.props.dispatch(navActions.setAction("CONTENT", {
-      id: 2,
-      action: this.props.onLike,
-    }));
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -315,7 +308,7 @@ export default connect(mapStateToProps)(
     withStudy(
       ReactMixin.decorate(Shareable)(
         canLike(
-          (props) => (props.study.loading ? null : props.study.content.id)
+          (props) => (props.studyEntry.loading ? null : props.studyEntry.content.entryId)
         )(StudyEntrySingle)
       )
     )

--- a/imports/pages/studies/entry/index.js
+++ b/imports/pages/studies/entry/index.js
@@ -7,7 +7,7 @@ import gql from "graphql-tag";
 import Meta from "../../../components/shared/meta";
 import Loading from "../../../components/@primitives/UI/loading";
 
-import Likeable from "../../../deprecated/mixins/mixins.Likeable";
+import CanLike from "../../../components/@enhancers/can-like";
 import Shareable from "../../../deprecated/mixins/mixins.Shareable";
 
 // import contentHelpers from "../../../util/content";
@@ -52,7 +52,7 @@ class StudyEntrySingle extends Component {
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
-      action: this.likeableAction,
+      action: this.props.onLike,
     }));
   }
 
@@ -312,10 +312,8 @@ const mapStateToProps = (state) => ({
 export default connect(mapStateToProps)(
   withCurrentStudyEntry(
     withStudy(
-      ReactMixin.decorate(Likeable)(
-        ReactMixin.decorate(Shareable)(
-          StudyEntrySingle
-        )
+      ReactMixin.decorate(Shareable)(
+        CanLike(StudyEntrySingle)
       )
     )
   )

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/NewSpring/holzman",
   "jest": {
     "transform": {
-        ".*": "./imports/util/tests/jestPreprocessor.js"
+      ".*": "./imports/util/tests/jestPreprocessor.js"
     },
     "coverageDirectory": "./.coverage",
     "collectCoverageFrom": [
@@ -92,7 +92,7 @@
   },
   "dependencies": {
     "aphrodite": "https://github.com/NewSpring/aphrodite.git#release",
-    "apollo-client": "^0.5.20",
+    "apollo-client": "^0.8.1",
     "audio5": "^0.1.10",
     "bcrypt": "^0.8.7",
     "bluebird": "^3.4.6",
@@ -115,7 +115,7 @@
     "moment": "^2.14.1",
     "react": "^15.0.0",
     "react-addons-pure-render-mixin": "^15.1.0",
-    "react-apollo": "^0.7.1",
+    "react-apollo": "^0.9.0",
     "react-async-script-loader": "^0.2.1",
     "react-controllables": "^0.6.0",
     "react-day-picker": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "dependencies": {
     "aphrodite": "https://github.com/NewSpring/aphrodite.git#release",
-    "apollo-client": "^0.8.1",
+    "apollo-client": "0.5.20",
     "audio5": "^0.1.10",
     "bcrypt": "^0.8.7",
     "bluebird": "^3.4.6",
@@ -115,7 +115,7 @@
     "moment": "^2.14.1",
     "react": "^15.0.0",
     "react-addons-pure-render-mixin": "^15.1.0",
-    "react-apollo": "^0.9.0",
+    "react-apollo": "0.7.1",
     "react-async-script-loader": "^0.2.1",
     "react-controllables": "^0.6.0",
     "react-day-picker": "^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,33 +139,13 @@
   version "2.0.33"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.33.tgz#e676d725e21fff68cc392c02d9db1f6e57a4441c"
 
-"@types/chai@^3.4.32":
-  version "3.4.34"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.4.34.tgz#d5335792823bb09cddd5e38c3d211b709183854d"
+"@types/graphql@^0.8.0":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.8.6.tgz#b34fb880493ba835b0c067024ee70130d6f9bb68"
 
 "@types/isomorphic-fetch@0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.30.tgz#a21717624cde9a48c2db53a4e500fc5c32a99bbc"
-
-"@types/lodash@^4.14.34":
-  version "4.14.39"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.39.tgz#99e2180351609e4466abde8952d153a63a03eb14"
-
-"@types/node@^6.0.38":
-  version "6.0.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.48.tgz#86ccc15f66b73cbbc5eb3483398936c585122b3c"
-
-"@types/promises-a-plus@0.0.26":
-  version "0.0.26"
-  resolved "https://registry.yarnpkg.com/@types/promises-a-plus/-/promises-a-plus-0.0.26.tgz#64d992f8e715dc6bb975766391eae54985fa4fe2"
-
-"@types/redux@^3.5.29":
-  version "3.6.31"
-  resolved "https://registry.yarnpkg.com/@types/redux/-/redux-3.6.31.tgz#40eafa7575db36b912ce0059b85de98c205b0708"
-
-"@types/sinon@^1.16.29":
-  version "1.16.32"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-1.16.32.tgz#b3246844902d7cb33f376b369b176a65a144af7e"
 
 Base64@~0.2.0:
   version "0.2.1"
@@ -315,26 +295,19 @@ anymatch@^1.3.0:
     asap "^2.0.3"
     inline-style-prefix-all "^2.0.0"
 
-apollo-client@^0.5.20:
-  version "0.5.20"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-0.5.20.tgz#2e9085ace68b8e7061ccb192be44dc0539f2c1a1"
+apollo-client@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-0.8.1.tgz#a7032e88f75170b35db2ac3c3acfd2b4adbf9a2a"
   dependencies:
-    graphql-anywhere "^1.0.0"
+    graphql-anywhere "^2.1.0"
     graphql-tag "^1.1.1"
-    lodash "^4.17.2"
-    redux "^3.3.1"
+    redux "^3.4.0"
     symbol-observable "^1.0.2"
     whatwg-fetch "^2.0.0"
   optionalDependencies:
     "@types/async" "^2.0.31"
-    "@types/chai" "^3.4.32"
+    "@types/graphql" "^0.8.0"
     "@types/isomorphic-fetch" "0.0.30"
-    "@types/lodash" "^4.14.34"
-    "@types/node" "^6.0.38"
-    "@types/promises-a-plus" "0.0.26"
-    "@types/redux" "^3.5.29"
-    "@types/sinon" "^1.16.29"
-    typed-graphql "1.0.2"
 
 append-transform@^0.3.0:
   version "0.3.0"
@@ -1628,19 +1601,19 @@ babel-runtime@6.11.6:
     core-js "^2.4.0"
     regenerator-runtime "^0.9.5"
 
-babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.5.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1, babel-runtime@^6.9.2:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.18.0.tgz#0f4177ffd98492ef13b9f823e9994a02584c9078"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.9.5"
-
-babel-runtime@^6.20.0:
+babel-runtime@6.x.x, babel-runtime@^6.18.0, babel-runtime@^6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.2.0, babel-runtime@^6.5.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1, babel-runtime@^6.9.2:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.18.0.tgz#0f4177ffd98492ef13b9f823e9994a02584c9078"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.9.5"
 
 babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.3.0, babel-template@^6.8.0:
   version "6.16.0"
@@ -3947,9 +3920,9 @@ graceful-fs@~2.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql-anywhere@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-1.1.2.tgz#897d2868d35723ce7d8b4ead3455c285ea51a2d2"
+graphql-anywhere@^2.0.0, graphql-anywhere@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-2.1.0.tgz#888c0a1718db3ff866b313070747777380560f69"
 
 graphql-tag@^0.1.8:
   version "0.1.17"
@@ -5620,7 +5593,7 @@ lodash.words@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.12.0, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.16.6, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.12.0, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.16.6, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
@@ -7014,10 +6987,11 @@ react-addons-test-utils@^15.3.2:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/react-addons-transition-group/-/react-addons-transition-group-15.4.0.tgz#dbcb8a6a466c6d54f347710345e0004b699a68e0"
 
-react-apollo@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-0.7.1.tgz#cbd51b5c4b011b55da3fa461dc0f9d7aa48d1f88"
+react-apollo@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-0.9.0.tgz#a95d05ccf2f92b16a21fd41795e2876c9ea28d6e"
   dependencies:
+    graphql-anywhere "^2.0.0"
     hoist-non-react-statics "^1.2.0"
     invariant "^2.2.1"
     lodash.flatten "^4.2.0"
@@ -7025,6 +6999,8 @@ react-apollo@^0.7.1:
     lodash.isobject "^3.0.2"
     lodash.pick "^4.4.0"
     object-assign "^4.0.1"
+  optionalDependencies:
+    react-dom "0.14.x || 15.* || ^15.0.0"
 
 react-async-script-loader@^0.2.1:
   version "0.2.1"
@@ -7089,7 +7065,7 @@ react-docgen@^2.12.1:
     nomnom "^1.8.1"
     recast "^0.11.5"
 
-react-dom@^15.0.0:
+"react-dom@0.14.x || 15.* || ^15.0.0", react-dom@^15.0.0:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.0.tgz#6a97a69000966570db48c746bc4b7b0ca50d1534"
   dependencies:
@@ -7572,7 +7548,7 @@ redux-saga@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.11.1.tgz#dc2023d059af0b91c0b1b4febce21194b67d5a58"
 
-redux@^3.0.4, redux@^3.3.1, redux@^3.5.2:
+redux@^3.0.4, redux@^3.4.0, redux@^3.5.2:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
   dependencies:
@@ -8460,10 +8436,6 @@ type-is@~1.6.13, type-is@~1.6.6:
     media-typer "0.3.0"
     mime-types "~2.1.13"
 
-typed-graphql@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/typed-graphql/-/typed-graphql-1.0.2.tgz#4c0f788775d552df4d4ec3d73f25469252f40fb8"
-
 typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -8827,17 +8799,17 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz#078b9461bbe91cea73cbce8bb122a05f9e92b772"
+whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 
 whatwg-fetch@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
 
-whatwg-fetch@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
+whatwg-fetch@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz#078b9461bbe91cea73cbce8bb122a05f9e92b772"
 
 whatwg-url-compat@~0.6.5:
   version "0.6.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,13 +139,33 @@
   version "2.0.33"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.33.tgz#e676d725e21fff68cc392c02d9db1f6e57a4441c"
 
-"@types/graphql@^0.8.0":
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.8.6.tgz#b34fb880493ba835b0c067024ee70130d6f9bb68"
+"@types/chai@^3.4.32":
+  version "3.4.34"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.4.34.tgz#d5335792823bb09cddd5e38c3d211b709183854d"
 
 "@types/isomorphic-fetch@0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.30.tgz#a21717624cde9a48c2db53a4e500fc5c32a99bbc"
+
+"@types/lodash@^4.14.34":
+  version "4.14.52"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.52.tgz#de5c7ab14da1289733233c9b0ec6f9e377db90f5"
+
+"@types/node@^6.0.38":
+  version "6.0.62"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.62.tgz#85222c077b54f25b57417bb708b9f877bda37f89"
+
+"@types/promises-a-plus@0.0.26":
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/@types/promises-a-plus/-/promises-a-plus-0.0.26.tgz#64d992f8e715dc6bb975766391eae54985fa4fe2"
+
+"@types/redux@^3.5.29":
+  version "3.6.31"
+  resolved "https://registry.yarnpkg.com/@types/redux/-/redux-3.6.31.tgz#40eafa7575db36b912ce0059b85de98c205b0708"
+
+"@types/sinon@^1.16.29":
+  version "1.16.34"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-1.16.34.tgz#a9761fff33d0f7b3fe61875b577778a2576a9a03"
 
 Base64@~0.2.0:
   version "0.2.1"
@@ -295,19 +315,26 @@ anymatch@^1.3.0:
     asap "^2.0.3"
     inline-style-prefix-all "^2.0.0"
 
-apollo-client@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-0.8.1.tgz#a7032e88f75170b35db2ac3c3acfd2b4adbf9a2a"
+apollo-client@0.5.20:
+  version "0.5.20"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-0.5.20.tgz#2e9085ace68b8e7061ccb192be44dc0539f2c1a1"
   dependencies:
-    graphql-anywhere "^2.1.0"
+    graphql-anywhere "^1.0.0"
     graphql-tag "^1.1.1"
-    redux "^3.4.0"
+    lodash "^4.17.2"
+    redux "^3.3.1"
     symbol-observable "^1.0.2"
     whatwg-fetch "^2.0.0"
   optionalDependencies:
     "@types/async" "^2.0.31"
-    "@types/graphql" "^0.8.0"
+    "@types/chai" "^3.4.32"
     "@types/isomorphic-fetch" "0.0.30"
+    "@types/lodash" "^4.14.34"
+    "@types/node" "^6.0.38"
+    "@types/promises-a-plus" "0.0.26"
+    "@types/redux" "^3.5.29"
+    "@types/sinon" "^1.16.29"
+    typed-graphql "1.0.2"
 
 append-transform@^0.3.0:
   version "0.3.0"
@@ -3920,9 +3947,9 @@ graceful-fs@~2.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql-anywhere@^2.0.0, graphql-anywhere@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-2.1.0.tgz#888c0a1718db3ff866b313070747777380560f69"
+graphql-anywhere@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-1.1.2.tgz#897d2868d35723ce7d8b4ead3455c285ea51a2d2"
 
 graphql-tag@^0.1.8:
   version "0.1.17"
@@ -5593,7 +5620,7 @@ lodash.words@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.12.0, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.16.6, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.12.0, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.16.6, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
@@ -6987,11 +7014,10 @@ react-addons-test-utils@^15.3.2:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/react-addons-transition-group/-/react-addons-transition-group-15.4.0.tgz#dbcb8a6a466c6d54f347710345e0004b699a68e0"
 
-react-apollo@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-0.9.0.tgz#a95d05ccf2f92b16a21fd41795e2876c9ea28d6e"
+react-apollo@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-0.7.1.tgz#cbd51b5c4b011b55da3fa461dc0f9d7aa48d1f88"
   dependencies:
-    graphql-anywhere "^2.0.0"
     hoist-non-react-statics "^1.2.0"
     invariant "^2.2.1"
     lodash.flatten "^4.2.0"
@@ -6999,8 +7025,6 @@ react-apollo@^0.9.0:
     lodash.isobject "^3.0.2"
     lodash.pick "^4.4.0"
     object-assign "^4.0.1"
-  optionalDependencies:
-    react-dom "0.14.x || 15.* || ^15.0.0"
 
 react-async-script-loader@^0.2.1:
   version "0.2.1"
@@ -7065,7 +7089,7 @@ react-docgen@^2.12.1:
     nomnom "^1.8.1"
     recast "^0.11.5"
 
-"react-dom@0.14.x || 15.* || ^15.0.0", react-dom@^15.0.0:
+react-dom@^15.0.0:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.0.tgz#6a97a69000966570db48c746bc4b7b0ca50d1534"
   dependencies:
@@ -7548,7 +7572,7 @@ redux-saga@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.11.1.tgz#dc2023d059af0b91c0b1b4febce21194b67d5a58"
 
-redux@^3.0.4, redux@^3.4.0, redux@^3.5.2:
+redux@^3.0.4, redux@^3.3.1, redux@^3.5.2:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
   dependencies:
@@ -8436,6 +8460,10 @@ type-is@~1.6.13, type-is@~1.6.6:
     media-typer "0.3.0"
     mime-types "~2.1.13"
 
+typed-graphql@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/typed-graphql/-/typed-graphql-1.0.2.tgz#4c0f788775d552df4d4ec3d73f25469252f40fb8"
+
 typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -8799,17 +8827,17 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
+whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz#078b9461bbe91cea73cbce8bb122a05f9e92b772"
 
 whatwg-fetch@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
 
-whatwg-fetch@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz#078b9461bbe91cea73cbce8bb122a05f9e92b772"
+whatwg-fetch@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 
 whatwg-url-compat@~0.6.5:
   version "0.6.5"


### PR DESCRIPTION
**I'm mostly opening this now so either of you can give me feedback on how this works.**

# Feature / Fixed Issue(s)
- adds likes enhancer for replacing the likes mixin.
- I use the query from the parent. I look for an object in `props` that has a child key of `id` or `entryId` instead of having an `if` for every type of content (see the current mixin).
- removes the likes mixin from usage.
- adds the ability to like a group ✊ 
`Note`: you'll need to test this by calling the likes feed query, since profile likes don't use the heighliner query yet. The profile likes looks for things (like name) that the toggle query doesn't add (since it doesn't need to)

# Testing/Documentation
- ✅  mixin is tested 

# Screenshots

<img width="1617" alt="screen shot 2017-01-25 at 7 17 06 pm" src="https://cloud.githubusercontent.com/assets/9259509/22315441/9a91a88a-e334-11e6-84d4-676cf243066e.png">