### PR TITLE
Newspring Now

### DIFF
--- a/imports/pages/events/Entry.js
+++ b/imports/pages/events/Entry.js
@@ -1,0 +1,7 @@
+// @flow
+
+const Entry = () => (
+  <div><p>This is an event entry</p></div>
+);
+
+export default Entry;

--- a/imports/pages/events/__tests__/__snapshots__/index.js.snap
+++ b/imports/pages/events/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,16 @@
+exports[`Event 1. renders with props 1`] = `
+<div>
+  <p>
+    This is an event
+  </p>
+</div>
+`;
+
+exports[`Event 2. pulls the route and snapshots it 1`] = `
+Array [
+  Object {
+    "component": [Function],
+    "path": "events/:id",
+  },
+]
+`;

--- a/imports/pages/events/__tests__/index.js
+++ b/imports/pages/events/__tests__/index.js
@@ -1,0 +1,15 @@
+import { shallow } from "enzyme";
+import { shallowToJson } from "enzyme-to-json";
+import Event from "../";
+
+describe("Event", () => {
+  it("1. renders with props", () => {
+    const wrapper = shallow(<Event.Event />);
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+
+  it("2. pulls the route and snapshots it", () => {
+    const wrapper = Event.Routes;
+    expect(wrapper).toMatchSnapshot();
+  });
+})

--- a/imports/pages/events/index.js
+++ b/imports/pages/events/index.js
@@ -1,0 +1,13 @@
+// @flow
+import Entry from "./Entry";
+
+const Event = () => <div><p>This is an event</p></div>;
+
+const Routes = [
+  { path: "events/:id", component: Entry },
+];
+
+export default {
+  Event,
+  Routes,
+};

--- a/imports/pages/index.js
+++ b/imports/pages/index.js
@@ -13,6 +13,7 @@ if (process.env.NATIVE) {
   import Locations from "./locations";
   import Music from "./music";
   import News from "./news";
+  import Event from "./events";
   import Sections from "./sections";
   import Series from "./series";
   import Stories from "./stories";
@@ -38,6 +39,7 @@ if (process.env.NATIVE) {
     Locations.Routes,
     Music.Routes,
     News.Routes,
+    Event.Routes,
     Sections.Routes,
     Series.Routes,
     Stories.Routes,


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Added the ability to show a NewSpring Now event in the home feed. This can be shown or hidden based on a particular person's role.
- Added a page that will read an entry in the NS: Now channel in EE and display the information.

# Testing/Documentation
- [ ] All significant new logic is covered by tests.
- [ ] Storybook documentation has been added.
- [ ] Changelog has been updated.

# Screenshots
- If applicable, include screenshots of UI/style changes.