### PR TITLE
Fix Color Switching on Mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed an issue in iOS that was causing schedules to not be created.
 - Fixed the toggle import in the `/following` section on profile causing component not to render.
 - Fixed an issue with the devotionals auto scrolling about half way down the page in the app on first render.
+- Fixed: The tag gallery would revert back to system color when the selected button wasn't "actively pressed". Added a "nohover" class to fix this.
 
 ## [1.2.3] - 2017-01-09
 ### Added

--- a/imports/components/@primitives/UI/tag-gallery/index.js
+++ b/imports/components/@primitives/UI/tag-gallery/index.js
@@ -67,7 +67,8 @@ class TagGalleryWithoutData extends Component {
           {
             `#${this.props.id} .tag--clickable:hover { background-color: ${this.props.buttonColor}; }
             #${this.props.id} .tag--active { background-color: ${this.props.buttonColor}; }
-            #${this.props.id} .tag--disabled { background-color: ${this.props.disabledColor} }`
+            #${this.props.id} .tag--disabled { background-color: ${this.props.disabledColor}; }
+            #${this.props.id} .tag--nohover--active { background-color: ${this.props.buttonColor}; }`
           }
         </style>
         <TagSelect


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Fixed: The tag gallery would revert back to system color when the selected button wasn't "actively pressed". Added a "nohover" class to fix this.