### PR TITLE
Added Promotions Category Back

### DIFF
--- a/imports/util/categories/__tests__/categories.name.js
+++ b/imports/util/categories/__tests__/categories.name.js
@@ -26,3 +26,8 @@ it("returns `Events` for `newspring_now`", () => {
   const result = categoryName({ channelName: "newspring_now" });
   expect(result).toBe("Events");
 });
+
+it("returns `Need to Know` for `promotions_newspring`", () => {
+  const result = categoryName({ channelName: "promotions_newspring" });
+  expect(result).toBe("Need to Know");
+});

--- a/imports/util/categories/categories.name.js
+++ b/imports/util/categories/categories.name.js
@@ -12,6 +12,8 @@ function categoryName(contentItem) {
       return "Albums";
     case "newspring_now":
       return "Events";
+    case "promotions_newspring":
+      return "Need to Know";
     default:
       // XXX this handles the case of `articless` but not `articles`
       // i think this is wrong


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Added back the check for `promotions_newspring` in category name that I accidentally removed

before:

![image](https://cloud.githubusercontent.com/assets/9259509/22565800/7fdf185a-e957-11e6-8353-876bc728cdbc.png)

after:

![screen shot 2017-02-02 at 2 54 35 pm](https://cloud.githubusercontent.com/assets/9259509/22565817/8b969812-e957-11e6-8404-c60a75498598.png)
