### PR TITLE
Change home tab to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed the toggle import in the `/following` section on profile causing component not to render.
 - Fixed an issue with the devotionals auto scrolling about half way down the page in the app on first render.
 - Fixed: The tag gallery would revert back to system color when the selected button wasn't "actively pressed". Added a "nohover" class to fix this.
+- Fixed the "Home" tab on Giving to now say "Dashboard". Because clarity.
 
 ## [1.2.3] - 2017-01-09
 ### Added

--- a/imports/pages/give/Layout.js
+++ b/imports/pages/give/Layout.js
@@ -21,7 +21,7 @@ class Layout extends Component {
         isActive: false,
         linkUrl: "/give/home",
         onClick: () => {},
-        title: "Home",
+        title: "Dashboard",
       },
       {
         isActive: false,
@@ -87,7 +87,7 @@ class Layout extends Component {
           <DashboardLayout
             title="My Giving"
             subNav={this.state.subNav}
-            additionalClasses={"soft-half-sides push-right"}
+            additionalClasses={"soft-half-sides push-half-right"}
           >
             {cloneElement(this.props.children, {
               setRightProps: this.setRightProps,

--- a/imports/pages/give/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/pages/give/__tests__/__snapshots__/Layout.js.snap
@@ -6,14 +6,14 @@ exports[`test renders a layout 1`] = `
   </Connect(SplitContainerWithoutData)>
   <Left>
     <Connect(Dashboard)
-      additionalClasses="soft-half-sides push-right"
+      additionalClasses="soft-half-sides push-half-right"
       subNav={
         Array [
           Object {
             "isActive": true,
             "linkUrl": "/give/home",
             "onClick": [Function],
-            "title": "Home",
+            "title": "Dashboard",
           },
           Object {
             "isActive": false,


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Change the home tab description to say "Dashboard" instead of "Home" because it was too easy to be confused with the home of the app.