### PR TITLE
added support for saving a payment on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed the toggle import in the `/following` section on profile causing component not to render.
 - Fixed an issue with the devotionals auto scrolling about half way down the page in the app on first render.
 - Fixed: The tag gallery would revert back to system color when the selected button wasn't "actively pressed". Added a "nohover" class to fix this.
+- Feature: Added ability to save a payment during a transaction on iOS
 
 ## [1.2.3] - 2017-01-09
 ### Added

--- a/imports/components/giving/checkout-views/fieldsets/confirm/__tests__/__snapshots__/index.js.snap
+++ b/imports/components/giving/checkout-views/fieldsets/confirm/__tests__/__snapshots__/index.js.snap
@@ -18,6 +18,7 @@ exports[`test renders ScheduleLayout if schedules 1`] = `
       header
     </span>
   }
+  payment={Object {}}
   savedAccount={Object {}}
   schedule={
     Object {
@@ -45,6 +46,7 @@ exports[`test renders TransactionLayout by default 1`] = `
       header
     </span>
   }
+  payment={Object {}}
   savedAccount={Object {}}
   schedule={
     Object {

--- a/imports/components/giving/checkout-views/fieldsets/confirm/index.js
+++ b/imports/components/giving/checkout-views/fieldsets/confirm/index.js
@@ -43,11 +43,12 @@ export default class Confirm extends Component {
     let { url } = props;
     const { transactions, total, data, savedAccount } = props;
 
+    const name = data.payment.name;
     // remove sensitive information
     delete data.billing; delete data.payment;
 
-    // add last 4 in
-    data.payment = {};
+    // add name in for saving the account
+    data.payment = { name };
 
     if (url.length === 0) url = false;
 

--- a/imports/components/giving/checkout-views/fieldsets/shared/SavePaymentCheckBox.js
+++ b/imports/components/giving/checkout-views/fieldsets/shared/SavePaymentCheckBox.js
@@ -1,6 +1,5 @@
 // @flow
 import Forms from "../../../../@primitives/UI/forms";
-import { isIOS } from "../../../../../util";
 
 type ISavePaymentCheckBox = {
   savedAccount: Object,
@@ -20,8 +19,7 @@ const SavePaymentCheckBox = ({
   if (
     !savedAccount.id &&
     transactionType !== "guest" &&
-    !schedule.start &&
-    !isIOS()
+    !schedule.start
   ) {
     return (
       <Forms.Checkbox

--- a/imports/components/giving/checkout-views/fieldsets/shared/SavePaymentInput.js
+++ b/imports/components/giving/checkout-views/fieldsets/shared/SavePaymentInput.js
@@ -1,9 +1,6 @@
 // @flow
 import Forms from "../../../../@primitives/UI/forms";
 
-import { isIOS } from "../../../../../util";
-
-
 type ISavePaymentInput = {
   saveName: Function,
   savedAccount: Object,
@@ -25,8 +22,7 @@ const SavePaymentInput = ({
     shouldSaveState &&
     !savedAccount.id &&
     transactionType !== "guest" &&
-    !schedule.start &&
-    (transactionType === "savedPayment" || !isIOS())
+    !schedule.start
   ) {
     return (
       <Forms.Input


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Added ability to save a payment on iOS

> this requires no changes to production heighliner or production my.newspring.cc. It is an app only change

NEEDS QA

# Testing/Documentation
- [x] All significant new logic is covered by tests.
- [x] Changelog has been updated.

# Screenshots
- If applicable, include screenshots of UI/style changes.

# QA Process
All new features and fixes should be tested and signed off on in the [device testing document](https://docs.google.com/spreadsheets/d/1TG0jmltkp61oRA4nYpcoGFTh1lDxa1A8dSnitBKT0lk/edit#gid=1270385294) that corresponds to this PR. **This PR should be tested and PASS on all devices/breakpoints prior to releasing.**

# Reporting Bugs
If you find an issue, a bug, or something that seems weird, thank you! That is extremely helpful. You can report this kind of feedback using our [GitHub Issues page](https://github.com/NewSpring/Holtzman/issues). Here are a few things that are great to include in an issue:

- Reference to this pull request.
- Steps to reproduce the issue
- Explanation of the buggy behavior
- Explanation of the expected behavior
- Screenshots of the app if helpful

Here is a link to a [good example issue.](https://github.com/NewSpring/Apollos/issues/841)
