### PR TITLE
UI changes for getting group info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed an issue with the devotionals auto scrolling about half way down the page in the app on first render.
 - Fixed: The tag gallery would revert back to system color when the selected button wasn't "actively pressed". Added a "nohover" class to fix this.
 
+### Changed
+- UI for joining a group
+  - changed join group button to say `get info`
+  - Groups: changed join group modal title to say `contact`
+  - changed default message for joining a group
+
 ## [1.2.3] - 2017-01-09
 ### Added
 - `index.js` files for folders with collections of components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - UI for joining a group
-  - changed join group button to say `get info`
-  - Groups: changed join group modal title to say `contact`
+  - changed join group button to say `Contact`
+  - Groups: changed join group modal title to say `Contact`
   - changed default message for joining a group
 
 ## [1.2.3] - 2017-01-09

--- a/imports/pages/groups/profile/Join.js
+++ b/imports/pages/groups/profile/Join.js
@@ -33,21 +33,22 @@ export default class Join extends Component {
     const leaders = group.members.filter((x) => (x.role.toLowerCase() === "leader"));
     const firstNames = leaders.map((x) => (x.person.nickName || x.person.firstName)).join(", ");
 
-    const message = `\nHey ${firstNames},\n\nI'm interested in joining your group and ` +
+    const message = `\nHey ${firstNames},\n\nI'm interested in learning more about your group and ` +
       "looking forward to hearing from you soon!\n\nThanks!";
     switch (this.state.state) {
       case "loading":
-        return <Loading msg="We're sending your request!" />;
+        return <Loading msg="We're sending your message!" />;
       case "error":
-        return <Err msg="There was a problem sending your request" error={this.state.err} />;
+        return <Err msg="There was a problem sending your message" error={this.state.err} />;
       case "success":
         return (
           <div className="soft soft-double-ends one-whole text-center">
             <h4 className="text-center push-ends">
-              Request Sent!
+              Message Sent!
             </h4>
             <p>
-              We have sent your request to join {group.name} to the group leaders!
+              We have sent your request for more information
+              about {group.name} to the group leaders!
             </p>
             <button className="btn--thin btn--small btn--dark-tertiary one-whole" onClick={onExit}>
               Close
@@ -58,7 +59,7 @@ export default class Join extends Component {
         return (
           <div className="soft soft-double-ends one-whole text-center">
             <h4 className="text-center push-ends">
-              Request to Join {group.name}
+              Contact {group.name}
             </h4>
             <Forms.Form
               id="message-form"

--- a/imports/pages/groups/profile/Layout.js
+++ b/imports/pages/groups/profile/Layout.js
@@ -108,7 +108,7 @@ const Layout = ({ group, leaders, isLeader, join }) => (
 
               return (
                 <button onClick={() => join()} className={className}>
-                  Join Group
+                  Get Info
                 </button>
               );
             })()}

--- a/imports/pages/groups/profile/Layout.js
+++ b/imports/pages/groups/profile/Layout.js
@@ -108,7 +108,7 @@ const Layout = ({ group, leaders, isLeader, join }) => (
 
               return (
                 <button onClick={() => join()} className={className}>
-                  Get Info
+                  Contact
                 </button>
               );
             })()}

--- a/imports/pages/groups/profile/__tests__/__snapshots__/Join.js.snap
+++ b/imports/pages/groups/profile/__tests__/__snapshots__/Join.js.snap
@@ -3,7 +3,7 @@ exports[`test renders with props 1`] = `
   className="soft soft-double-ends one-whole text-center">
   <h4
     className="text-center push-ends">
-    Request to Join 
+    Contact 
     happy group
   </h4>
   <Form
@@ -24,7 +24,7 @@ exports[`test renders with props 1`] = `
       defaultValue="
     Hey jim, bob,
     
-    I\'m interested in joining your group and looking forward to hearing from you soon!
+    I\'m interested in learning more about your group and looking forward to hearing from you soon!
     
     Thanks!"
       inputClasses="text-dark-secondary"

--- a/imports/pages/groups/profile/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/pages/groups/profile/__tests__/__snapshots__/Layout.js.snap
@@ -87,7 +87,7 @@ exports[`test doesn't render Interest type tag 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Get Info
+            Contact
           </button>
         </div>
       </div>
@@ -350,7 +350,7 @@ exports[`test doesn't render demographic tag if none 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Get Info
+            Contact
           </button>
         </div>
       </div>
@@ -613,7 +613,7 @@ exports[`test renders adult only version 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Get Info
+            Contact
           </button>
         </div>
       </div>
@@ -1141,7 +1141,7 @@ exports[`test renders with props 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Get Info
+            Contact
           </button>
         </div>
       </div>
@@ -1404,7 +1404,7 @@ exports[`test renders without campus 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Get Info
+            Contact
           </button>
         </div>
       </div>
@@ -1667,7 +1667,7 @@ exports[`test renders without group locations 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Get Info
+            Contact
           </button>
         </div>
       </div>
@@ -1930,7 +1930,7 @@ exports[`test renders without schedule 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Get Info
+            Contact
           </button>
         </div>
       </div>
@@ -2193,7 +2193,7 @@ exports[`test renders without schedule description 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Get Info
+            Contact
           </button>
         </div>
       </div>

--- a/imports/pages/groups/profile/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/pages/groups/profile/__tests__/__snapshots__/Layout.js.snap
@@ -87,7 +87,7 @@ exports[`test doesn't render Interest type tag 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Join Group
+            Get Info
           </button>
         </div>
       </div>
@@ -350,7 +350,7 @@ exports[`test doesn't render demographic tag if none 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Join Group
+            Get Info
           </button>
         </div>
       </div>
@@ -613,7 +613,7 @@ exports[`test renders adult only version 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Join Group
+            Get Info
           </button>
         </div>
       </div>
@@ -1141,7 +1141,7 @@ exports[`test renders with props 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Join Group
+            Get Info
           </button>
         </div>
       </div>
@@ -1404,7 +1404,7 @@ exports[`test renders without campus 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Join Group
+            Get Info
           </button>
         </div>
       </div>
@@ -1667,7 +1667,7 @@ exports[`test renders without group locations 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Join Group
+            Get Info
           </button>
         </div>
       </div>
@@ -1930,7 +1930,7 @@ exports[`test renders without schedule 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Join Group
+            Get Info
           </button>
         </div>
       </div>
@@ -2193,7 +2193,7 @@ exports[`test renders without schedule description 1`] = `
           <button
             className="flush-bottom push-half-bottom@handheld btn"
             onClick={[Function]}>
-            Join Group
+            Get Info
           </button>
         </div>
       </div>


### PR DESCRIPTION
 Feature / Fixed Issue(s)
- changed join group button to say `Contact`
- changed join group modal title to say `contact`
- changed default message for joining a group

# Testing/Documentation
- [x] All significant new logic is covered by tests.
- [x] Changelog has been updated.

# Screenshots
![screen shot 2017-02-08 at 3 43 03 pm](https://cloud.githubusercontent.com/assets/9259509/22756649/cbdd7c0c-ee15-11e6-86e6-b53d799df218.png)
![screen shot 2017-02-08 at 3 43 39 pm](https://cloud.githubusercontent.com/assets/9259509/22756650/ce5e8cd2-ee15-11e6-9551-3e069f672afd.png)
