### PR TITLE
Changed History Filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Changed the text on the individual transaction entry pages to more closely align with our church's vision.
+- Changed the giving history filters to show a "Last Year" option
 
 ## [1.2.3] - 2017-01-09
 ### Added

--- a/imports/pages/give/history/Filter.js
+++ b/imports/pages/give/history/Filter.js
@@ -7,7 +7,7 @@ import Tag from "../../../components/@primitives/UI/tags";
 import Date from "../../../components/giving/add-to-cart/Schedule/Date";
 
 const DATE_RANGES = [
-  { label: "Last Year", value: "LastYear" },
+  { label: moment().subtract(1, "year").format("Y"), value: "LastYear" },
   { label: "Last Month", value: "LastMonth" },
   { label: "Year To Date", value: "YearToDate" },
   { label: "All Time", value: "AllTime" },
@@ -86,12 +86,12 @@ export default class Filter extends Component {
 
       let startDate;
       let endDate;
-      if (value === "LastMonth") {
-        startDate = moment().subtract(30, "days");
-        endDate = moment();
-      } else if (value === "LastYear") {
+      if (value === "LastYear") {
         startDate = moment().subtract(1, "year").startOf("year");
         endDate = moment().subtract(1, "year").endOf("year");
+      } else if (value === "LastMonth") {
+        startDate = moment().subtract(30, "days");
+        endDate = moment();
       } else if (value === "YearToDate") {
         startDate = moment().startOf("year");
         endDate = moment();

--- a/imports/pages/give/history/Filter.js
+++ b/imports/pages/give/history/Filter.js
@@ -7,8 +7,8 @@ import Tag from "../../../components/@primitives/UI/tags";
 import Date from "../../../components/giving/add-to-cart/Schedule/Date";
 
 const DATE_RANGES = [
+  { label: "Last Year", value: "LastYear" },
   { label: "Last Month", value: "LastMonth" },
-  { label: "Last 6 Months", value: "LastSixMonths" },
   { label: "Year To Date", value: "YearToDate" },
   { label: "All Time", value: "AllTime" },
 ];
@@ -89,9 +89,9 @@ export default class Filter extends Component {
       if (value === "LastMonth") {
         startDate = moment().subtract(30, "days");
         endDate = moment();
-      } else if (value === "LastSixMonths") {
-        startDate = moment().subtract(6, "months");
-        endDate = moment();
+      } else if (value === "LastYear") {
+        startDate = moment().subtract(1, "year").startOf("year");
+        endDate = moment().subtract(1, "year").endOf("year");
       } else if (value === "YearToDate") {
         startDate = moment().startOf("year");
         endDate = moment();

--- a/imports/pages/give/history/__tests__/Filter.js
+++ b/imports/pages/give/history/__tests__/Filter.js
@@ -174,20 +174,19 @@ it("dataRangeClick with LastMonth value sets the start and end dates correctly",
   expect(wrapper.state().end).toEqual("");
 })
 
-it("dataRangeClick with LastSixMonths value sets the start and end dates correctly", () => {
+it("dataRangeClick with LastYear value sets the start and end dates correctly", () => {
   const wrapper = shallow(generateComponent());
   wrapper.setState({
     start: "",
     end: "",
   });
 
-  // this should set a 6 month range
-  wrapper.instance().dateRangeClick("LastSixMonths");
-  expect(moment(wrapper.state().start).format("L")).toEqual(moment().subtract(6, "months").format("L"));
-  expect(moment(wrapper.state().end).format("L")).toEqual(moment().format("L"));
+  wrapper.instance().dateRangeClick("LastYear");
+  expect(moment(wrapper.state().start).format("L")).toEqual(moment().subtract(1, "year").startOf("year").format("L"));
+  expect(moment(wrapper.state().end).format("L")).toEqual(moment().subtract(1, "year").endOf("year").format("L"));
 
   // calling it again should reset the start and end dates
-  wrapper.instance().dateRangeClick("LastSixMonths");
+  wrapper.instance().dateRangeClick("LastYear");
   expect(wrapper.state().start).toEqual("");
   expect(wrapper.state().end).toEqual("");
 })

--- a/imports/pages/give/history/__tests__/__snapshots__/Filter.js.snap
+++ b/imports/pages/give/history/__tests__/__snapshots__/Filter.js.snap
@@ -38,12 +38,12 @@ exports[`test doesn't render family members if there are none 1`] = `
           items={
             Array [
               Object {
-                "label": "Last Month",
-                "value": "LastMonth",
+                "label": "2016",
+                "value": "LastYear",
               },
               Object {
-                "label": "Last 6 Months",
-                "value": "LastSixMonths",
+                "label": "Last Month",
+                "value": "LastMonth",
               },
               Object {
                 "label": "Year To Date",
@@ -193,12 +193,12 @@ exports[`test renders family members when expanded is true 1`] = `
           items={
             Array [
               Object {
-                "label": "Last Month",
-                "value": "LastMonth",
+                "label": "2016",
+                "value": "LastYear",
               },
               Object {
-                "label": "Last 6 Months",
-                "value": "LastSixMonths",
+                "label": "Last Month",
+                "value": "LastMonth",
               },
               Object {
                 "label": "Year To Date",
@@ -376,12 +376,12 @@ exports[`test works with nickname 1`] = `
           items={
             Array [
               Object {
-                "label": "Last Month",
-                "value": "LastMonth",
+                "label": "2016",
+                "value": "LastYear",
               },
               Object {
-                "label": "Last 6 Months",
-                "value": "LastSixMonths",
+                "label": "Last Month",
+                "value": "LastMonth",
               },
               Object {
                 "label": "Year To Date",


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- in giving history, the first filter now is for `Last Year`
- sets the startDate and endDate for lookup to be start and end of previous calendar year.

# Testing/Documentation
- [x] All significant new logic is covered by tests.
- [x] Changelog has been updated.

# Screenshots

❕ Ignore the tag label being "Last Year" right here. It's actually 2016 as shown in the second image
![screen shot 2017-02-09 at 3 22 59 pm](https://cloud.githubusercontent.com/assets/9259509/22802159/cd9628b4-eedd-11e6-82c1-8a087080e2d4.png)
![screen shot 2017-02-09 at 3 35 00 pm](https://cloud.githubusercontent.com/assets/9259509/22802161/cebd5cf8-eedd-11e6-81e7-0c288c1a598c.png)
