### PR TITLE
ensure app id is set

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -79,6 +79,12 @@ platform :ios do
       value: "Group Finder",
     )
 
+    update_app_identifier(
+      xcodeproj: "#{ENV['METEOR_OUTPUT_ABSOLUTE']}/ios/project/#{ENV['XCODE_SCHEME_NAME']}.xcodeproj",
+      plist_path: "#{ENV['METEOR_OUTPUT_ABSOLUTE']}/ios/project/#{ENV['XCODE_SCHEME_NAME']}/#{ENV['XCODE_SCHEME_NAME']}-Info.plist",
+      app_identifier: ENV['APP_IDENTIFIER'],
+    )
+
     gym(
       project: "#{ENV['METEOR_OUTPUT_ABSOLUTE']}/ios/project/#{ENV['XCODE_SCHEME_NAME']}.xcodeproj",
       scheme: ENV['XCODE_SCHEME_NAME'],


### PR DESCRIPTION
production iOS builds are broken because the app identifier doesn't match the id inside the certificate. This fastlane action sets the `APP_IDENTIFIER`.
