### PR TITLE
Fix Validation

### DIFF
--- a/imports/pages/groups/profile/__tests__/index.js
+++ b/imports/pages/groups/profile/__tests__/index.js
@@ -210,6 +210,18 @@ it("should call validatePhoneNumber and return false", () => {
   expect(result).toBe(false);
 });
 
+it("should call validatePhoneNumber with characters and numbers and return true", () => {
+  const wrapper = shallow(generateComponent());
+  let result = wrapper.instance().validatePhoneNumber("1234abcdef1a2b3c4d56");
+  expect(result).toBe(true);
+});
+
+it("should call validatePhoneNumber with characters and numbers and return false", () => {
+  const wrapper = shallow(generateComponent());
+  let result = wrapper.instance().validatePhoneNumber("1234abcdef1a2b3c4d5e");
+  expect(result).toBe(false);
+});
+
 it("calls onCommunicationPreferenceChange and sets the state", () => {
   const wrapper = shallow(generateComponent());
   wrapper.setState({ communicationPreference: "No Preference" });

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -119,7 +119,7 @@ class TemplateWithoutData extends Component {
   }
 
   validatePhoneNumber = (value: string): boolean => {
-    if (value.length < 10) return false;
+    if (value.replace(/[^\d]+/g, "").length < 10) return false;
     return true;
   }
 


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Fixed validation to only fail if there are 10 or fewer DIGITS. It was just checking to see if there were 10 or less total characters. Which would be wrong if there was a entered phone number of "1234dfdfdf". After stripping off the non-digits, the phone number would be "1234"...which is wrong. Bonus: I discovered this while writing the documentation. 🎉 