### PR TITLE
Hide recent likes on discover on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed the "Home" tab on Giving to now say "Dashboard". Because clarity.
 - Fixed a typo on the Annual Report. The KidSpring section story now spells "among" correctly.
 - Fixed the security enhancer so that it correctly shows the home feed if you are not signed in.
+- Removed recently liked section on web.
 
 ### Changed
 - Changed the text on the individual transaction entry pages to more closely align with our church's vision.

--- a/imports/components/discover/feed/Layout.js
+++ b/imports/components/discover/feed/Layout.js
@@ -1,9 +1,6 @@
 
-// @flow
-
 import { PropTypes } from "react";
 import { Link } from "react-router";
-
 import Loading from "../../@primitives/UI/loading/Spinner";
 import Hero from "../../@primitives/UI/hero";
 import { MiniCard } from "../../@primitives/UI/cards";
@@ -23,18 +20,12 @@ function getImage(images, label = "2:1") {
   return selectedImage;
 }
 
-type IRenderRecentLikes = {
-  recentLikes: boolean,
-  recentLoading: [Object],
-  show: boolean,
-};
-
 const RenderRecentLikes = ({
   recentLikes,
   recentLoading,
   show,
-}: IRenderRecentLikes) => {
-  if (!show) return null; //|| (!recentLoading && !(recentLikes && recentLikes.length))) return null;
+}) => {
+  if (!show) return null;
   return (
     <section className="soft-half background--light-secondary">
       {(recentLoading || (!recentLoading && recentLikes && recentLikes.length)) &&
@@ -48,12 +39,10 @@ const RenderRecentLikes = ({
   );
 };
 
-type ILayout = {
-  featuredItem: Object,
-  recommendedItems: [Object],
-  textItems: [Object],
-  recentLikes: [Object],
-  recentLoading: boolean,
+RenderRecentLikes.propTypes = {
+  recentLikes: PropTypes.object,
+  recentLoading: PropTypes.bool,
+  show: PropTypes.bool,
 };
 
 const Layout = ({
@@ -62,7 +51,7 @@ const Layout = ({
   textItems,
   recentLikes,
   recentLoading,
-}: ILayout) => (
+}) => (
   <div style={{ overflowY: "hidden", height: "100%" }} className="background--light-primary">
 
     <section className="hard background--light-secondary">
@@ -127,6 +116,14 @@ const Layout = ({
     )}
   </div>
 );
+
+Layout.propTypes = {
+  featuredItem: PropTypes.object,
+  recommendedItems: PropTypes.array,
+  textItems: PropTypes.array,
+  recentLikes: PropTypes.array,
+  recentLoading: PropTypes.bool,
+};
 
 export default Layout;
 

--- a/imports/components/discover/feed/Layout.js
+++ b/imports/components/discover/feed/Layout.js
@@ -1,3 +1,6 @@
+
+// @flow
+
 import { PropTypes } from "react";
 import { Link } from "react-router";
 
@@ -20,21 +23,37 @@ function getImage(images, label = "2:1") {
   return selectedImage;
 }
 
+type IRenderRecentLikes = {
+  recentLikes: boolean,
+  recentLoading: [Object],
+  show: boolean,
+};
+
 const RenderRecentLikes = ({
   recentLikes,
   recentLoading,
-}) => {
-  if (!process.env.WEB) {
-    return (
-      <section className="soft-half background--light-secondary">
+  show,
+}: IRenderRecentLikes) => {
+  if (!show) return null; //|| (!recentLoading && !(recentLikes && recentLikes.length))) return null;
+  return (
+    <section className="soft-half background--light-secondary">
+      {(recentLoading || (!recentLoading && recentLikes && recentLikes.length)) &&
         <div className="one-whole text-center">
           <h5 className="flush soft-bottom">Recently Liked By Others</h5>
         </div>
-        {recentLoading && <div className="text-center"><Loading /></div>}
-        {recentLikes && <RecentLikes likes={recentLikes} />}
-      </section>)
-  };
-  return null;
+      }
+      {recentLoading && <div className="text-center" data-spec="loading"><Loading /></div>}
+      {recentLikes && <RecentLikes likes={recentLikes} />}
+    </section>
+  );
+};
+
+type ILayout = {
+  featuredItem: Object,
+  recommendedItems: [Object],
+  textItems: [Object],
+  recentLikes: [Object],
+  recentLoading: boolean,
 };
 
 const Layout = ({
@@ -43,7 +62,7 @@ const Layout = ({
   textItems,
   recentLikes,
   recentLoading,
-}) => (
+}: ILayout) => (
   <div style={{ overflowY: "hidden", height: "100%" }} className="background--light-primary">
 
     <section className="hard background--light-secondary">
@@ -71,6 +90,7 @@ const Layout = ({
     <RenderRecentLikes
       recentLikes={recentLikes}
       recentLoading={recentLoading}
+      show={!process.env.WEB}
     />
 
     {textItems && (
@@ -105,38 +125,12 @@ const Layout = ({
         </div>
       </div>
     )}
-
-
-    {/*
-    <section className="hard background--light-secondary">
-      <h6 className="push-left soft-half-bottom soft-top">Popular Content</h6>
-    </section>
-
-    <section className="soft-half background--light-secondary">
-      <div className="grid">
-        {popularItems.map(function(item, i) {
-          return (
-            <div className="grid__item one-whole" key={i}>
-              <PopularItem like={item} />
-            </div>
-          )
-        })}
-      </div>
-    </section>
-    */}
   </div>
 );
-
-Layout.propTypes = {
-  featuredItem: PropTypes.object,
-  recommendedItems: PropTypes.array,
-  textItems: PropTypes.array,
-  recentLikes: PropTypes.array,
-  recentLoading: PropTypes.bool,
-};
 
 export default Layout;
 
 export {
+  RenderRecentLikes,
   getImage,
 };

--- a/imports/components/discover/feed/Layout.js
+++ b/imports/components/discover/feed/Layout.js
@@ -20,6 +20,23 @@ function getImage(images, label = "2:1") {
   return selectedImage;
 }
 
+const RenderRecentLikes = ({
+  recentLikes,
+  recentLoading,
+}) => {
+  if (!process.env.WEB) {
+    return (
+      <section className="soft-half background--light-secondary">
+        <div className="one-whole text-center">
+          <h5 className="flush soft-bottom">Recently Liked By Others</h5>
+        </div>
+        {recentLoading && <div className="text-center"><Loading /></div>}
+        {recentLikes && <RecentLikes likes={recentLikes} />}
+      </section>)
+  };
+  return null;
+};
+
 const Layout = ({
   featuredItem,
   recommendedItems,
@@ -51,13 +68,10 @@ const Layout = ({
       </div>
     </section>
 
-    <section className="soft-half background--light-secondary">
-      <div className="one-whole text-center">
-        <h5 className="flush soft-bottom">Recently Liked By Others</h5>
-      </div>
-      {recentLoading && <div className="text-center"><Loading /></div>}
-      {recentLikes && !process.env.WEB && <RecentLikes likes={recentLikes} />}
-    </section>
+    <RenderRecentLikes
+      recentLikes={recentLikes}
+      recentLoading={recentLoading}
+    />
 
     {textItems && (
       <div className="soft-half background--light-secondary">

--- a/imports/components/discover/feed/Layout.js
+++ b/imports/components/discover/feed/Layout.js
@@ -56,7 +56,7 @@ const Layout = ({
         <h5 className="flush soft-bottom">Recently Liked By Others</h5>
       </div>
       {recentLoading && <div className="text-center"><Loading /></div>}
-      {recentLikes && <RecentLikes likes={recentLikes} />}
+      {recentLikes && !process.env.WEB && <RecentLikes likes={recentLikes} />}
     </section>
 
     {textItems && (

--- a/imports/components/discover/feed/__tests__/Layout.js
+++ b/imports/components/discover/feed/__tests__/Layout.js
@@ -1,6 +1,9 @@
 import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
-import Layout, { getImage } from "../Layout";
+import Layout, { getImage, RenderRecentLikes } from "../Layout";
+import Loading from "../../../@primitives/UI/Loading/spinner";
+import { getSingleSpecWrapper } from "../../../../util/tests/data-spec";
+import RecentLikes from "../../../shared/likes-list";
 
 describe("getImage", () => {
   it("returns 2:1 by default", () => {
@@ -116,4 +119,48 @@ describe("Layout", () => {
     }));
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
+});
+
+describe("RenderRecentLikes", () => {
+
+  const defaultProps = {
+    recentLikes: [],
+    recentLoading: false,
+    show: true,
+  };
+
+  const generateComponent = (additionalProps = {}) => {
+    const newProps = {
+      ...defaultProps,
+      ...additionalProps,
+    };
+    return <RenderRecentLikes { ...newProps } />;
+  };
+
+  beforeEach(() => {
+
+  });
+
+  it("should not render with no likes", () => {
+    const component = shallow(generateComponent({ show: true, recentLoading: false, recentLikes: null }));
+    expect(shallowToJson(component)).toEqual(null);
+  });
+
+  it("should not render if on web", () => {
+    const component = shallow(generateComponent({ show: false }));
+    expect(shallowToJson(component)).toEqual(null);
+  });
+
+  it("should render loading if it is loading", () => {
+    const component = shallow(generateComponent({ recentLoading: true, show: true }));
+    expect(component.find("Spinner").length).toEqual(1);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
+  fit("should render likes if not loading", () => {
+    const component = shallow(generateComponent({ recentLoading: false, show: true, recentLikes: ["yo", "dawg"] }));
+    expect(component.find("Spinner").length).toEqual(0);
+    expect(shallowToJson(component)).toMatchSnapshot();
+  });
+
 });

--- a/imports/components/discover/feed/__tests__/Layout.js
+++ b/imports/components/discover/feed/__tests__/Layout.js
@@ -1,7 +1,6 @@
 import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
 import Layout, { getImage, RenderRecentLikes } from "../Layout";
-import Loading from "../../../@primitives/UI/Loading/spinner";
 import { getSingleSpecWrapper } from "../../../../util/tests/data-spec";
 import RecentLikes from "../../../shared/likes-list";
 

--- a/imports/components/discover/feed/__tests__/__snapshots__/Layout.js.snap
+++ b/imports/components/discover/feed/__tests__/__snapshots__/Layout.js.snap
@@ -78,16 +78,7 @@ exports[`Layout renders with props 1`] = `
         title="recommend two" />
     </div>
   </section>
-  <section
-    className="soft-half background--light-secondary">
-    <div
-      className="one-whole text-center">
-      <h5
-        className="flush soft-bottom">
-        Recently Liked By Others
-      </h5>
-    </div>
-  </section>
+  <RenderRecentLikes />
   <div
     className="soft-half background--light-secondary">
     <div
@@ -190,16 +181,7 @@ exports[`Layout works without featured item 1`] = `
         title="recommend two" />
     </div>
   </section>
-  <section
-    className="soft-half background--light-secondary">
-    <div
-      className="one-whole text-center">
-      <h5
-        className="flush soft-bottom">
-        Recently Liked By Others
-      </h5>
-    </div>
-  </section>
+  <RenderRecentLikes />
   <div
     className="soft-half background--light-secondary">
     <div
@@ -235,4 +217,44 @@ exports[`Layout works without featured item 1`] = `
     </div>
   </div>
 </div>
+`;
+
+exports[`RenderRecentLikes should render likes if not loading 1`] = `
+<section
+  className="soft-half background--light-secondary">
+  <div
+    className="one-whole text-center">
+    <h5
+      className="flush soft-bottom">
+      Recently Liked By Others
+    </h5>
+  </div>
+  <Component
+    likes={
+      Array [
+        "yo",
+        "dawg",
+      ]
+    } />
+</section>
+`;
+
+exports[`RenderRecentLikes should render loading if it is loading 1`] = `
+<section
+  className="soft-half background--light-secondary">
+  <div
+    className="one-whole text-center">
+    <h5
+      className="flush soft-bottom">
+      Recently Liked By Others
+    </h5>
+  </div>
+  <div
+    className="text-center"
+    data-spec="loading">
+    <Spinner />
+  </div>
+  <Component
+    likes={Array []} />
+</section>
 `;


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Removed recent likes section from discover on web

# Testing/Documentation
- [x] Changelog has been updated.

# Screenshots

**NATIVE**
<img width="434" alt="screen shot 2017-02-15 at 4 06 46 pm" src="https://cloud.githubusercontent.com/assets/9259509/22995421/d8acb6ea-f398-11e6-8da7-3d9d3386c82d.png">

**WEB**
<img width="451" alt="screen shot 2017-02-15 at 4 02 47 pm" src="https://cloud.githubusercontent.com/assets/9259509/22995306/53dd0db6-f398-11e6-8330-43f1ce35879e.png">
