### PR TITLE
Fixed sign in from groups finder

### DIFF
--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -34,8 +34,9 @@ const PHONE_QUERY = gql`
 export const JoinWithPhones = graphql(PHONE_QUERY, {
   name: "phoneNumbers",
   props: ({ phoneNumbers }) => ({
-    phonesLoading: phoneNumbers.loading,
-    phones: phoneNumbers.loading ? null : phoneNumbers.currentPerson.phoneNumbers,
+    phonesLoading: phoneNumbers && phoneNumbers.loading ? phoneNumbers.loading : true,
+    phones:
+      !phoneNumbers.length || phoneNumbers.loading ? null : phoneNumbers.currentPerson.phoneNumbers,
   }),
 })(Join);
 

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -121,11 +121,7 @@ class TemplateWithoutData extends Component {
   }
 
   validatePhoneNumber = (value: string): boolean => {
-<<<<<<< HEAD
     if (value.replace(/[^\d]+/g, "").length < 10) return false;
-=======
-    if (value.length < 10) return false;
->>>>>>> All Things Group Joining (#1814)
     return true;
   }
 

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -120,7 +120,11 @@ class TemplateWithoutData extends Component {
   }
 
   validatePhoneNumber = (value: string): boolean => {
+<<<<<<< HEAD
     if (value.replace(/[^\d]+/g, "").length < 10) return false;
+=======
+    if (value.length < 10) return false;
+>>>>>>> All Things Group Joining (#1814)
     return true;
   }
 


### PR DESCRIPTION
- Fixed an issue where you couldn't sign in from the groups page because the phone number was null. The signing you in spinner continually looped. The phoneNumber prop was null (which in my head makes sense because you hadn't been signed in yet), so it didn't know how to pull the current phone numbers. It actually signed you in (you could test this by closing the modal), but it would never go to the next step in the process. This seems to fix that.