### PR TITLE
Fix the breaking schedule tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed the "Home" tab on Giving to now say "Dashboard". Because clarity.
 - Fixed a typo on the Annual Report. The KidSpring section story now spells "among" correctly.
 - Fixed the security enhancer so that it correctly shows the home feed if you are not signed in.
+- Fixed schedule tags breaking in giving when changed from one tag to another
 
 ### Changed
 - Changed the text on the individual transaction entry pages to more closely align with our church's vision.

--- a/imports/components/giving/add-schedule/Layout.js
+++ b/imports/components/giving/add-schedule/Layout.js
@@ -26,23 +26,6 @@ type ILayout = {
   dataId: string | number,
 };
 
-// this definition of Layout won't render
-// const Layout = ({
-//   accounts,
-//   existing,
-//   format,
-//   onSubmitSchedule,
-//   ready,
-//   save,
-//   saveDate,
-//   schedules,
-//   setFrequency,
-//   setFund,
-//   state,
-//   text,
-//   total,
-// }: ILayout) => {
-
 // this definition of Layout works
 class Layout extends Component {
 

--- a/imports/components/giving/add-to-cart/Schedule/__tests__/index.js
+++ b/imports/components/giving/add-to-cart/Schedule/__tests__/index.js
@@ -200,6 +200,18 @@ describe("Class", () => {
       });
       expect(wrapper.state().frequency).toEqual(null);
     });
+    it("changes frequency", () => {
+      const saveSchedule = jest.fn();
+      const wrapper = mount(generateComponent({ saveSchedule }));
+      const { frequencyClick } = wrapper.instance();
+      wrapper.setState({ start: "now", frequency: "one-time" });
+      frequencyClick("monthly");
+      expect(saveSchedule).toBeCalledWith({
+        frequency: "monthly",
+        start: "now",
+      });
+      expect(wrapper.state().frequency).toEqual("monthly");
+    });
   });
 
   describe("startClick", () => {
@@ -231,6 +243,18 @@ describe("Class", () => {
         start: null,
       });
       expect(wrapper.state().start).toEqual(null);
+    });
+    it("changes the start", () => {
+      const saveSchedule = jest.fn();
+      const wrapper = mount(generateComponent({ saveSchedule }));
+      const { startClick } = wrapper.instance();
+      wrapper.setState({ start: "now", frequency: "one-time" });
+      startClick("l8r");
+      expect(saveSchedule).toBeCalledWith({
+        frequency: "one-time",
+        start: "l8r",
+      });
+      expect(wrapper.state().start).toEqual("l8r");
     });
     it("toggles the date picker (true)", () => {
       const wrapper = mount(generateComponent());

--- a/imports/components/giving/add-to-cart/Schedule/index.js
+++ b/imports/components/giving/add-to-cart/Schedule/index.js
@@ -130,9 +130,14 @@ export class Schedule extends Component {
     });
   }
 
+  /*
+    if one is selected, and freqClick is called with the same one, disable it
+    if one is selected, and freqClick is called with another one, SET THAT ONE
+    if one is not selected, set it
+  */
   frequencyClick = (value: string) => {
     let newValue = value;
-    if (this.state.frequency) newValue = null;
+    if (this.state.frequency === newValue) newValue = null;
 
     this.setState({ frequency: newValue });
     this.props.saveSchedule({
@@ -143,7 +148,7 @@ export class Schedule extends Component {
 
   startClick = (value: string) => {
     let newValue = value;
-    if (this.state.start) newValue = null;
+    if (this.state.start === newValue) newValue = null;
 
     if (this.state.start || value !== "custom") {
       this.setState({ start: newValue });


### PR DESCRIPTION
resolves #1801 

# Feature / Fixed Issue(s)
- The tag select function wasn't updated when when the tag select component was changed to allow clicking from one tag directly to another.
- The two tag select functions now check 3 states:
    1. if one is selected, and freqClick is called with the same one, disable it
    2. if one is selected, and freqClick is called with another one, SET THAT ONE
    3. if one is not selected, set it

# Testing/Documentation
- [ ] All significant new logic is covered by tests.
- [ ] Changelog has been updated.

# QA
- To QA, look at #1801 and follow instructions there
