### PR TITLE
Fix Topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed a typo on the Annual Report. The KidSpring section story now spells "among" correctly.
 - Fixed the security enhancer so that it correctly shows the home feed if you are not signed in.
 - Fixed schedule tags breaking in giving when changed from one tag to another
+- Fixed the home feed so that it will only show you all of the basic topics if you are signed out.
 
 ### Changed
 - Changed the text on the individual transaction entry pages to more closely align with our church's vision.

--- a/imports/data/store/topics/index.js
+++ b/imports/data/store/topics/index.js
@@ -7,6 +7,7 @@
 */
 import reducer from "./reducer";
 import { addReducer } from "../utilities";
+import "./saga";
 
 addReducer({
   topics: reducer,

--- a/imports/data/store/topics/saga.js
+++ b/imports/data/store/topics/saga.js
@@ -1,0 +1,17 @@
+/* eslint-disable import/no-named-as-default-member */
+import "regenerator-runtime/runtime";
+import { takeEvery } from "redux-saga";
+import { fork, put } from "redux-saga/effects";
+
+import { addSaga } from "../utilities";
+
+import actions from "./";
+
+function* signout({ state }) {
+  if (state !== "signout") return;
+  yield put(actions.set([]));
+}
+
+addSaga(function* topicSaga() {
+  yield fork(takeEvery, "ACCOUNTS.SET_STATE", signout);
+});

--- a/imports/pages/home/index.js
+++ b/imports/pages/home/index.js
@@ -175,7 +175,7 @@ const getTopics = (opts) => {
   channels = difference(topics, channels);
 
   // ensure channels aren't empty
-  if (channels.length === 0) channels = [...topics];
+  if (channels.length === 0 || !Meteor.userId()) channels = [...topics];
 
   // return for the graphql call
   return channels.filter(filterChannels).map((x) => x.toLowerCase());


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Fixed an issue where the topics weren't being cleared out on logout. The use case for needing this is that if you only had one topic selected, and it was a topic only meant for beta testers, then you signed out, the system returned `channels` as a blank array `[]` to Heighliner causing it to kind of puke up all kinds of unrelated things to show in the feed. Added a saga to clear out the topics on logout, and added a check to make sure that if there is no logged in user, it just shows the basic list of topics.