### PR TITLE
Fixed group contact modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed recently liked section on web.
 - Discover hero not linking out
 - Fixed currency wrapping in review checkout on $1000+ transactions
+- Contact group modal now shows phone number field if needed
 
 ### Changed
 - Changed the text on the individual transaction entry pages to more closely align with our church's vision.

--- a/imports/pages/groups/profile/__tests__/index.js
+++ b/imports/pages/groups/profile/__tests__/index.js
@@ -4,7 +4,13 @@ import { Meteor } from "meteor/meteor";
 import { print } from "graphql-tag/printer";
 import { modal } from "../../../../data/store";
 import OnBoard from "../../../../components/people/accounts";
-import { TemplateWithoutData as Template, JoinWithPhones, PHONE_NUMBER_MUTATION, GROUP_MUTATION } from "../";
+import {
+  TemplateWithoutData as Template,
+  JoinWithPhones,
+  PHONE_NUMBER_MUTATION,
+  GROUP_MUTATION,
+  phonePropsReducer,
+} from "../";
 
 jest.mock("../../../../deprecated/mixins/mixins.Header", () => {});
 jest.mock("../../../../data/store", () => ({
@@ -145,6 +151,37 @@ it("sendRequest calls preventDefault", () => {
   expect(mockPreventDefault).toHaveBeenCalledTimes(1);
   expect(mockQuerySelectorAll).toHaveBeenCalledTimes(1);
   expect(mockQuerySelectorAll).toHaveBeenCalledWith("textarea");
+});
+
+it("should reduce phonesLoading prop", () => {
+  // loading key is true
+  expect(phonePropsReducer({
+    phoneNumbers: { loading: true },
+  }).phonesLoading).toEqual(true);
+
+  // no phone numbers key
+  expect(phonePropsReducer({}).phonesLoading).toEqual(true);
+});
+
+it("should reduce phones prop", () => {
+  // loading key is true,
+  expect(phonePropsReducer({
+    phoneNumbers: {
+      loading: true,
+      currentPerson: { phoneNumbers: ["yo"] },
+    },
+  }).phones).toEqual(null);
+
+  //no phone numbers
+  expect(phonePropsReducer({
+    phoneNumbers: {
+      loading: false,
+      currentPerson: { phoneNumbers: [] },
+    },
+  }).phones).toEqual(null);
+  
+  // no phone numbers key
+  expect(phonePropsReducer({}).phones).toEqual(null);
 });
 
 it("join renders Join modal if user", () => {

--- a/imports/pages/groups/profile/index.js
+++ b/imports/pages/groups/profile/index.js
@@ -31,13 +31,17 @@ const PHONE_QUERY = gql`
   }
 `;
 
+export const phonePropsReducer = ({ phoneNumbers }) => ({
+  phonesLoading: phoneNumbers ? phoneNumbers.loading : true,
+  phones:
+    !phoneNumbers || phoneNumbers.loading || !phoneNumbers.currentPerson.phoneNumbers.length
+      ? null
+      : phoneNumbers.currentPerson.phoneNumbers,
+});
+
 export const JoinWithPhones = graphql(PHONE_QUERY, {
   name: "phoneNumbers",
-  props: ({ phoneNumbers }) => ({
-    phonesLoading: phoneNumbers && phoneNumbers.loading ? phoneNumbers.loading : true,
-    phones:
-      !phoneNumbers.length || phoneNumbers.loading ? null : phoneNumbers.currentPerson.phoneNumbers,
-  }),
+  props: phonePropsReducer,
 })(Join);
 
 export const PHONE_NUMBER_MUTATION = gql`


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- fixed the phone number input not showing up when a user chooses phone or text as preferred contact and they don't have a phone number on file

**Details**
- The loading prop was always being set to `true`
- The `phones` prop was always being set to null because `phoneNumbers` is an object, not an array, so its length was always undefined :grin:

# Testing/Documentation
- [x] All significant new logic is covered by tests.
- [x] Changelog has been updated.

# Screenshots
*It shows now*
<img width="420" alt="screen shot 2017-03-07 at 8 25 12 pm" src="https://cloud.githubusercontent.com/assets/9259509/23686486/d951a53a-0377-11e7-82f9-fbb2f380cef1.png">