### PR TITLE
Removed year from statement filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed the giving history filters to show a "Last Year" option
 - Changed the text on the giving dashboard, schedule detail, and adding a payment type during a schedule to bring clarity to our amazing people.
 - Changed the group sign up to be a request for information. Updated the UI to have text that speaks to requesting information and not joining the group. Allow the person signing up to choose their communication preference based on the choices in Rock. Allow the person to add a phone number if they do not have one in the database.
+- Giving summary file name no longer includes year
 
 ### Changed
 

--- a/imports/pages/give/history/index.js
+++ b/imports/pages/give/history/index.js
@@ -2,7 +2,6 @@
 import { Component, PropTypes } from "react";
 // $FlowMeteor
 import { Meteor } from "meteor/meteor";
-import moment from "moment";
 import { graphql } from "react-apollo";
 import gql from "graphql-tag";
 import fileSaver from "file-saver";
@@ -55,7 +54,7 @@ class TemplateWithoutData extends Component {
       .then(({ data: { transactionStatement } }) => {
         const blob = base64ToBlob(transactionStatement.file);
         this.setState({ printLoading: false });
-        fileSaver.saveAs(blob, `${moment().year()} NewSpring Church Giving Summary.pdf`);
+        fileSaver.saveAs(blob, "NewSpring Church Giving Summary.pdf");
       })
       .catch(() => {
         this.setState({ printLoading: false });


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Having the year in the statement filename is confusing if you're printing a statement for a previous year.

Also, one less use of moment 🎉 

# Testing/Documentation
- [x] Changelog has been updated.

# Screenshots
<img width="378" alt="screen shot 2017-03-07 at 9 02 46 pm" src="https://cloud.githubusercontent.com/assets/9259509/23686788/a67473a2-0379-11e7-8b4a-8000739acbeb.png">
