### PR TITLE
Fix Ellipses in Group Finder Results Not Showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - A day of week filter for group finder.
 
+### Fixed
+- Ellipses on last tag of group finder results being hidden with long lists of tags
+
 ## [5.0.17] - 2017-03-08
 ### Added
 - NewSpring Now!

--- a/imports/pages/groups/finder/ResultLayout.js
+++ b/imports/pages/groups/finder/ResultLayout.js
@@ -87,7 +87,7 @@ const Layout = ({
       ))}
       <Tag
         style={{ verticalAlign: "bottom" }}
-        className="flush-bottom background--dark-tertiary"
+        className="flush-bottom"
         val="..."
         canBeActive={false}
         onClick={() => toggleTags()}

--- a/imports/pages/groups/finder/__tests__/__snapshots__/ResultLayout.js.snap
+++ b/imports/pages/groups/finder/__tests__/__snapshots__/ResultLayout.js.snap
@@ -43,7 +43,7 @@ exports[`test renders spinner when loading is true 1`] = `
       val={1} />
     <withRouter(Connect(TagWithoutData))
       canBeActive={false}
-      className="flush-bottom background--dark-tertiary"
+      className="flush-bottom"
       onClick={[Function]}
       style={
         Object {
@@ -152,7 +152,7 @@ exports[`test renders with props 1`] = `
       val={1} />
     <withRouter(Connect(TagWithoutData))
       canBeActive={false}
-      className="flush-bottom background--dark-tertiary"
+      className="flush-bottom"
       onClick={[Function]}
       style={
         Object {


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- For SYS-3526
- One of the classes on the tag was setting overflow:hidden on the tag, which was causing it to hide the `...` when it was being pushed off the screen. Turns out that class doesn't actually have an effect on the appearance of the tag. I removed it. 

# Testing/Documentation
- [x] All significant new logic is covered by tests.
- [x] Changelog has been updated.

# Screenshots
![screen shot 2017-03-15 at 9 56 06 am](https://cloud.githubusercontent.com/assets/9259509/23952395/bef39c52-0967-11e7-97aa-ac09f8cf8473.png)
