### PR TITLE
Fixed reference error in siteLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [5.0.20] - UNRELEASED
+## [5.0.22]
+### Fixed
+- issue with siteLinks erroring out, causing content to never load
+
+## [5.0.20]
 ### Added
 - redirect on signin with person guid for work workflows.
 

--- a/imports/util/content/__tests__/content.siteLink.js
+++ b/imports/util/content/__tests__/content.siteLink.js
@@ -64,3 +64,8 @@ it("returns external link for news", () => {
   }));
   expect(result).toBe("https://newspring.cc/news/test-slug");
 });
+
+it("gracefully fails if a study with no parent", () => {
+  const result = siteLink(getContentItem({ channelName: "study_entries"}));
+  expect(result).toBe("https://newspring.cc/studies/undefined/test-slug");
+});

--- a/imports/util/content/content.siteLink.js
+++ b/imports/util/content/content.siteLink.js
@@ -1,18 +1,18 @@
-
 function siteLink(contentItem, parentItem) {
   const siteUrl = "https://newspring.cc";
   const slug = contentItem.meta.urlTitle;
   const category = contentItem.channelName;
+  const parentSlug = parentItem && parentItem.meta && parentItem.meta.urlTitle;
 
   switch (category) {
     case "series_newspring":
       return `${siteUrl}/sermons/${slug}`;
     case "sermons":
-      return `${siteUrl}/sermons/${parentItem.meta.urlTitle}/${slug}`;
+      return `${siteUrl}/sermons/${parentSlug}/${slug}`;
     case "studies":
       return `${siteUrl}/studies/${slug}`;
     case "study_entries":
-      return `${siteUrl}/studies/${parentItem.meta.urlTitle}/${slug}`;
+      return `${siteUrl}/studies/${parentSlug}/${slug}`;
     case "devotionals":
       return `${siteUrl}/devotionals/${slug}`;
     case "newspring_albums":
@@ -25,7 +25,6 @@ function siteLink(contentItem, parentItem) {
       return `${siteUrl}/news/${slug}`;
     default:
       return null;
-
   }
 }
 


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- siteLink was trying to access a deeply nested value at the wrong time and was throwing an error, causing the loading spinner to _sometimes_ go on forever

**note**: I couldn't seem to find the caller for this. I saw 2 references to siteLink in the project, and i couldn't get either to actually call, causing an error. This fix solves the problem, but I'm still not 100% sure _why_ it was a problem to begin with 😁

# Testing/Documentation
- [x] All significant new logic is covered by tests.
- [x] Changelog has been updated.
