### PR TITLE
Fix Custom Date Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [5.0.22] - UNRELEASED
+## [5.1.0] - UNRELEASED
+## Fixed
+- Unpredictable custom tag in give/now with schedules
+- Start/End date tags being active when they shouldn't in giving history
+
+## [5.0.22]
 ## Fixed
 - Giving statements filtered by all time only printing YTD
 - Giving history filters not allowing switching from one to another

--- a/imports/components/giving/add-to-cart/Schedule/__tests__/index.js
+++ b/imports/components/giving/add-to-cart/Schedule/__tests__/index.js
@@ -1,6 +1,7 @@
 import { mount, shallow } from "enzyme";
 import { mountToJson, shallowToJson } from "enzyme-to-json";
 import { connect } from "react-redux";
+import moment from "moment";
 
 import { give as giveActions } from "../../../../../data/store";
 
@@ -22,6 +23,8 @@ jest.mock("moment", () => (date) => ({
   add: (amount, time) => ({
     toISOString: (style) => `${date || "now"}.endOf(${time}).add(${amount}, ${time}).toISOString()`,
   }),
+  isValid: date => date !== "custom",
+  isSame: date => false,
 }));
 
 jest.mock("../Layout", () => jest.fn(() => <div />));
@@ -262,22 +265,22 @@ describe("Class", () => {
       startClick("custom");
       expect(wrapper.state().showDatePicker).toEqual(true);
     });
-    it("removes the state when it was custom", () => {
-      const saveSchedule = jest.fn();
-      const wrapper = mount(generateComponent({ saveSchedule }));
-      const { startClick } = wrapper.instance();
-      wrapper.setState({ start: "custom", frequency: "one-time" });
-      startClick("custom");
-      expect(saveSchedule).toBeCalledWith({
-        frequency: "one-time",
-        start: null,
-      });
-      expect(wrapper.state().start).toEqual(null);
-    });
+    // it("removes the state when it was custom", () => {
+    //   const saveSchedule = jest.fn();
+    //   const wrapper = mount(generateComponent({ saveSchedule }));
+    //   const { startClick } = wrapper.instance();
+    //   wrapper.setState({ start: "custom", frequency: "one-time" });
+    //   startClick("custom");
+    //   expect(saveSchedule).toBeCalledWith({
+    //     frequency: "one-time",
+    //     start: null,
+    //   });
+    //   expect(wrapper.state().start).toEqual(null);
+    // });
     it("toggles the date picker (false)", () => {
       const wrapper = mount(generateComponent());
       const { startClick } = wrapper.instance();
-      wrapper.setState({ showDatePicker: true });
+      wrapper.setState({ showDatePicker: true, activeStartTag: "Custom" });
       startClick("custom");
       expect(wrapper.state().showDatePicker).toEqual(false);
     });

--- a/imports/components/giving/add-to-cart/Schedule/__tests__/index.js
+++ b/imports/components/giving/add-to-cart/Schedule/__tests__/index.js
@@ -221,8 +221,8 @@ describe("Class", () => {
     it("updates the state for start", () => {
       const wrapper = mount(generateComponent());
       const { startClick } = wrapper.instance();
-      startClick("one-time");
-      expect(wrapper.state().start).toEqual("one-time");
+      startClick("9000-01-01");
+      expect(wrapper.state().start).toEqual("9000-01-01");
     });
     it("saves the schedule", () => {
       const saveSchedule = jest.fn();
@@ -235,7 +235,7 @@ describe("Class", () => {
         start: "now",
       });
     });
-    it("removes the start", () => {
+    it("should allow toggling", () => {
       const saveSchedule = jest.fn();
       const wrapper = mount(generateComponent({ saveSchedule }));
       const { startClick } = wrapper.instance();
@@ -247,7 +247,7 @@ describe("Class", () => {
       });
       expect(wrapper.state().start).toEqual(null);
     });
-    it("changes the start", () => {
+    it("should allow switching tags", () => {
       const saveSchedule = jest.fn();
       const wrapper = mount(generateComponent({ saveSchedule }));
       const { startClick } = wrapper.instance();
@@ -265,18 +265,25 @@ describe("Class", () => {
       startClick("custom");
       expect(wrapper.state().showDatePicker).toEqual(true);
     });
-    // it("removes the state when it was custom", () => {
-    //   const saveSchedule = jest.fn();
-    //   const wrapper = mount(generateComponent({ saveSchedule }));
-    //   const { startClick } = wrapper.instance();
-    //   wrapper.setState({ start: "custom", frequency: "one-time" });
-    //   startClick("custom");
-    //   expect(saveSchedule).toBeCalledWith({
-    //     frequency: "one-time",
-    //     start: null,
-    //   });
-    //   expect(wrapper.state().start).toEqual(null);
-    // });
+    it("allows toggling of custom tag", () => {
+      const saveSchedule = jest.fn();
+      const wrapper = mount(generateComponent({ saveSchedule }));
+      const { startClick } = wrapper.instance();
+      const initialState = {
+        start: "9000-01-01",
+        frequency: "one-time",
+        activeStartTag: "Custom",
+        checked: true
+      };
+      wrapper.setState(s => initialState);
+      startClick("custom");
+      expect(wrapper.state()).toEqual({
+        ...initialState,
+        start: null,
+        showDatePicker: false,
+        activeStartTag: null,
+      });
+    });
     it("toggles the date picker (false)", () => {
       const wrapper = mount(generateComponent());
       const { startClick } = wrapper.instance();
@@ -326,5 +333,4 @@ describe("Class", () => {
       expect(wrapper.state()).toEqual(originalState);
     });
   });
-
 });

--- a/imports/components/giving/add-to-cart/Schedule/index.js
+++ b/imports/components/giving/add-to-cart/Schedule/index.js
@@ -147,7 +147,7 @@ export class Schedule extends Component {
   }
 
   startClick = (value: string) => {
-    const filtered = START_DATES.find(x => moment(x.value).isSame(value, "day"));
+    const filtered = START_DATES.find(x => moment(x.value).isValid() && moment(x.value).isSame(value, "day"));
     const label = filtered ? filtered.label : "Custom"; // the tag label
 
     // DATETIME || "custom"

--- a/imports/components/giving/add-to-cart/Schedule/index.js
+++ b/imports/components/giving/add-to-cart/Schedule/index.js
@@ -147,11 +147,16 @@ export class Schedule extends Component {
   }
 
   startClick = (value: string) => {
-    let newValue = value;
-    if (this.state.start === newValue) newValue = null;
+    const filtered = START_DATES.find(x => moment(x.value).isSame(value, "day"));
+    const label = filtered ? filtered.label : "Custom"; // the tag label
 
-    if (this.state.start || value !== "custom") {
-      this.setState({ start: newValue });
+    // DATETIME || "custom"
+    const newValue = this.state.start === value ? null : value;
+    const newStartTag = this.state.activeStartTag === label ? null : label;
+
+    // other tags have a start date, so update schedule
+    if (value !== "custom") {
+      this.setState(s => ({ start: newValue, activeStartTag: newStartTag }));
       this.props.saveSchedule({
         frequency: this.state.frequency,
         start: newValue,
@@ -159,7 +164,9 @@ export class Schedule extends Component {
       return;
     }
 
-    this.setState(({ showDatePicker }) => ({ showDatePicker: !showDatePicker }));
+    // custom doesn't need to save schedule.
+    // toggle date picker and clear previous set start dates
+    this.setState(({activeStartTag}) => ({ showDatePicker: activeStartTag !== "Custom", start: null, activeStartTag: newStartTag }));
   }
 
   onDayClick = (e, day, { selected, disabled }) => {

--- a/imports/pages/give/history/Filter.js
+++ b/imports/pages/give/history/Filter.js
@@ -333,6 +333,7 @@ export default class Filter extends Component {
                       !this.state.customStartActive &&
                       scheduleIcon
                   }
+                  clickAble={!Boolean(this.state.dateRangeActive)}
                 />
                 <Tag
                   key={2}
@@ -350,6 +351,7 @@ export default class Filter extends Component {
                       !this.state.customEndActive &&
                       scheduleIcon
                   }
+                  clickAble={!Boolean(this.state.dateRangeActive)}
                 />
               </div>
             </div>

--- a/imports/pages/give/history/__tests__/Filter.js
+++ b/imports/pages/give/history/__tests__/Filter.js
@@ -1,7 +1,10 @@
 import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
 import moment from "moment";
+import Tag from "../../../../components/@primitives/UI/tags";
 import Filter from "../Filter";
+
+jest.mock("../../../../components/@primitives/UI/tags");
 
 const defaultProps = {
   family: [
@@ -156,7 +159,7 @@ it("toggle changes the expanded state", () => {
   expect(wrapper.state().expanded).toBe(false);
 });
 
-it("dataRangeClick with LastMonth value sets the start and end dates correctly", () => {
+it("dateRangeClick with LastMonth value sets the start and end dates correctly", () => {
   const wrapper = shallow(generateComponent());
   wrapper.setState({
     start: "",
@@ -174,7 +177,7 @@ it("dataRangeClick with LastMonth value sets the start and end dates correctly",
   expect(wrapper.state().end).toEqual("");
 })
 
-it("dataRangeClick with LastYear value sets the start and end dates correctly", () => {
+it("dateRangeClick with LastYear value sets the start and end dates correctly", () => {
   const wrapper = shallow(generateComponent());
   wrapper.setState({
     start: "",
@@ -191,7 +194,7 @@ it("dataRangeClick with LastYear value sets the start and end dates correctly", 
   expect(wrapper.state().end).toEqual("");
 })
 
-it("dataRangeClick with YearToDate value sets the start and end dates correctly", () => {
+it("dateRangeClick with YearToDate value sets the start and end dates correctly", () => {
   const wrapper = shallow(generateComponent());
   wrapper.setState({
     start: "",
@@ -209,7 +212,7 @@ it("dataRangeClick with YearToDate value sets the start and end dates correctly"
   expect(wrapper.state().end).toEqual("");
 })
 
-it("dataRangeClick with AllTime sets limit correctly", () => {
+it("dateRangeClick with AllTime sets limit correctly", () => {
   const wrapper = shallow(generateComponent());
   wrapper.setState({
     limit: 20,
@@ -224,7 +227,7 @@ it("dataRangeClick with AllTime sets limit correctly", () => {
   expect(wrapper.state().limit).toEqual(20);
 })
 
-it("dataRangeClick sets customDateDisabled correctly", () => {
+it("dateRangeClick sets customDateDisabled correctly", () => {
   const wrapper = shallow(generateComponent());
   wrapper.setState({
     customDateDisabled: false,
@@ -246,6 +249,24 @@ it("dateRangeClick allows switching from one tag to another", () => {
   click("YearToDate");
   expect(wrapper.state().start).toEqual(moment().startOf("year"));
   expect(wrapper.state().dateRangeActive).toEqual("YearToDate");
+});
+
+it("dateRangeClick disables custom dates from being selected", () => {
+  const wrapper = shallow(generateComponent({ expanded: true, store: {} }));
+  wrapper.instance().toggle();
+  expect(wrapper.find(Tag).get(0).props.clickAble).toEqual(true);
+  const click = wrapper.instance().dateRangeClick;
+  click("AllTime");
+  expect(wrapper.find(Tag).get(0).props.clickAble).toEqual(false);
+});
+
+it("dateRangeClick toggling off enables custom dates", () => {
+  const wrapper = shallow(generateComponent({ expanded: true, store: {} }));
+  wrapper.instance().toggle();
+  const click = wrapper.instance().dateRangeClick;
+  click("AllTime");
+  click("AllTime");
+  expect(wrapper.find(Tag).get(0).props.clickAble).toEqual(true);
 });
 
 it("toggleStartDatePicker correctly toggles the start date picker", () => {

--- a/imports/pages/give/history/__tests__/__snapshots__/Filter.js.snap
+++ b/imports/pages/give/history/__tests__/__snapshots__/Filter.js.snap
@@ -70,6 +70,7 @@ exports[`test doesn't render family members if there are none 1`] = `
         <withRouter(Connect(TagWithoutData))
           active={false}
           className={false}
+          clickAble={true}
           icon={
             <span
               className="icon-calendar push-half-left"
@@ -86,6 +87,7 @@ exports[`test doesn't render family members if there are none 1`] = `
         <withRouter(Connect(TagWithoutData))
           active={false}
           className={false}
+          clickAble={true}
           icon={
             <span
               className="icon-calendar push-half-left"
@@ -225,6 +227,7 @@ exports[`test renders family members when expanded is true 1`] = `
         <withRouter(Connect(TagWithoutData))
           active={false}
           className={false}
+          clickAble={true}
           icon={
             <span
               className="icon-calendar push-half-left"
@@ -241,6 +244,7 @@ exports[`test renders family members when expanded is true 1`] = `
         <withRouter(Connect(TagWithoutData))
           active={false}
           className={false}
+          clickAble={true}
           icon={
             <span
               className="icon-calendar push-half-left"
@@ -408,6 +412,7 @@ exports[`test works with nickname 1`] = `
         <withRouter(Connect(TagWithoutData))
           active={false}
           className={false}
+          clickAble={true}
           icon={
             <span
               className="icon-calendar push-half-left"
@@ -424,6 +429,7 @@ exports[`test works with nickname 1`] = `
         <withRouter(Connect(TagWithoutData))
           active={false}
           className={false}
+          clickAble={true}
           icon={
             <span
               className="icon-calendar push-half-left"


### PR DESCRIPTION
- for SYS-3645

# Fixed Issue(s)
- The giving schedule start time tags didn't correctly support switching from one tag to another without toggling off a tag.
- The giving history custom start/end tags could still be tapped and interacted with even if they appeared disabled

# Testing/Documentation
- [x] All significant new logic is covered by tests.
- [x] Changelog has been updated.

# To QA
- in give/now, try to set up a schedule. Switching back and forth in start times should work as expected. 
  - The date picker should only open if you click on the `custom` tag when it's currently disabled. If the custom tag is enabled and you click it, it should disable the tag.
- In give/history filter by one of the main filters (e.g. All Time) and try to interact with the custom buttons.