### PR TITLE
Added saved payments back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [5.0.22] - UNRELEASED
+## [5.1.0] - UNRELEASED
+### Added
+- Added back the ability to save payments without a transaction.
+
+## [5.0.22]
 ## Fixed
 - Giving statements filtered by all time only printing YTD
 - Giving history filters not allowing switching from one to another

--- a/imports/data/store/give/saga/__tests__/chargeTransaction.js
+++ b/imports/data/store/give/saga/__tests__/chargeTransaction.js
@@ -206,5 +206,46 @@ describe("successful charge using a saved payment", () => {
     delete window.ga;
     expect(result).toBeUndefined();
   });
+});
 
+fdescribe("validating cards on saved payment creation", () => {
+  const giveData = {
+    personal: {},
+    billing: {},
+    payment: {
+      type: "cc"
+    },
+  };
+  const it = sagaHelper(chargeTransaction({ state: "submit" }));
+  const initalState = {
+    give: {
+      ...initial,
+      savedAccount: {},
+      data: giveData,
+    },
+  };
+
+  it("reads the state from the store", result => {
+    expect(result.SELECT).toBeTruthy();
+    return initalState;
+  });
+
+  it("skips over loading state", result => {});
+  it("skips over setting store the first time", result => {
+    return {};
+  });
+  it("passes give data", result => ({
+    give: {
+      url: "URL-Mc-URLface",
+      data: giveData,
+    }
+  }));
+
+  it("calls validation method", result => {
+    // validate calls select() first.
+    // if validate wasn't being called, the next yield in the file
+    // is a graphql call, so this would fail.
+    expect(result.SELECT).toBeDefined();
+    return { validationError: true };
+  });
 });

--- a/imports/data/store/give/saga/__tests__/chargeTransaction.js
+++ b/imports/data/store/give/saga/__tests__/chargeTransaction.js
@@ -8,6 +8,7 @@ import { Meteor } from "meteor/meteor";
 import { initial } from "../../reducer";
 import actions from "../../actions";
 import types from "../../types";
+import { validate } from "../";
 
 import { chargeTransaction } from "../";
 
@@ -49,6 +50,20 @@ describe("successful charge without saved payment", () => {
     expect(result).toEqual(take(types.SET_TRANSACTION_DETAILS));
     return { url: "https://example.com/TOKEN" };
   });
+
+  // STEP THROUGH VALIDATION
+  it("requires initial seed data", () => ({ give: { ...initial } }));
+  it("formats the data in the store", result => {
+    return { data: { response: { url: "http://test.com/TOKEN" } } };
+  });
+  it("tries to submit payment details with the data and url", result => {
+    result.next();
+    return null;
+  });
+  it("tries to submit payment details with the data and url", result => {
+    return { };
+  });
+  // DONE VALIDATING
 
   it("tries to submit a transaction with the correct token", result => {
     expect(result.CALL.args[0].variables).toEqual({

--- a/imports/data/store/give/saga/__tests__/chargeTransaction.js
+++ b/imports/data/store/give/saga/__tests__/chargeTransaction.js
@@ -208,7 +208,7 @@ describe("successful charge using a saved payment", () => {
   });
 });
 
-fdescribe("validating cards on saved payment creation", () => {
+describe("validating cards on saved payment creation", () => {
   const giveData = {
     personal: {},
     billing: {},

--- a/imports/data/store/give/saga/chargeTransaction.js
+++ b/imports/data/store/give/saga/chargeTransaction.js
@@ -56,21 +56,18 @@ export default function* chargeTransaction({ state }) {
   // get the token and name of the saved account
   const token = give.url.split("/").pop();
 
-  if (give.schedule.start) {
-    // if there is not a saved account, charge the order
-    if (!formattedData.savedAccount) {
-      if (give.data.payment.type === "cc") {
-        // saved accounts don't validate the payment by default
-        // so we make 3 blocking requests to validate the card :(
-        const { validationError } = yield* validate();
+  // if there is not a saved account, validate the payment
+  if (!formattedData.savedAccount) {
+    if (give.data.payment.type === "cc") {
+      // saved accounts don't validate the payment by default
+      // so we make 3 blocking requests to validate the card :(
+      const { validationError } = yield* validate();
 
-        if (validationError) {
-          error = validationError;
-        }
+      if (validationError) {
+        error = validationError;
       }
     }
   }
-
 
   if (give.scheduleToRecover && give.schedule.start) {
     id = give.scheduleToRecover;

--- a/imports/pages/give/home/SavedPayments.js
+++ b/imports/pages/give/home/SavedPayments.js
@@ -5,7 +5,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import LoadingCard from "../../../components/@primitives/UI/loading/ActivityCard";
 import SectionHeader from "../../../components/@primitives/UI/section-header";
-// import SmallButton from "../../../components/@primitives/UI/buttons/SmallButton";
+import SmallButton from "../../../components/@primitives/UI/buttons/SmallButton";
 import { modal } from "../../../data/store";
 
 import giveActions from "../../../data/store/give";
@@ -49,12 +49,12 @@ export class SavedPaymentsList extends Component {
   // without a second confirmatin during the next gift
   // this doesn't make sense
   // ~ Angry James
-  SavedPaymentsButton = () => null
-    // <SmallButton
-    //   text="Add Account"
-    //   onClick={this.openModal}
-    //   className="btn--dark-tertiary flush"
-    // />;
+  SavedPaymentsButton = () =>
+    <SmallButton
+      text="Add Account"
+      onClick={this.openModal}
+      className="btn--dark-tertiary flush"
+    />;
 
   renderPayments(payments: Object) {
     if (!Array.isArray(payments)) return null;

--- a/imports/pages/give/home/__tests__/__snapshots__/SavedPayments.js.snap
+++ b/imports/pages/give/home/__tests__/__snapshots__/SavedPayments.js.snap
@@ -67,7 +67,23 @@ exports[`Saved Payments List should render properly with data 1`] = `
         </div>
         <div
           className="one-half floating display-inline-block floating--right soft soft-half-right">
-          <Component />
+          <Component>
+            <SmallButton
+              className="btn--dark-tertiary flush"
+              onClick={[Function]}
+              text="Add Account">
+              <button
+                className="
+                  btn btn--small@next
+                  
+                  btn--dark-tertiary flush
+                "
+                onClick={[Function]}
+                style={Object {}}>
+                Add Account
+              </button>
+            </SmallButton>
+          </Component>
         </div>
       </div>
     </SectionHeader>
@@ -125,7 +141,23 @@ exports[`Saved Payments List should render without saved payments 1`] = `
         </div>
         <div
           className="one-half floating display-inline-block floating--right soft soft-half-right">
-          <Component />
+          <Component>
+            <SmallButton
+              className="btn--dark-tertiary flush"
+              onClick={[Function]}
+              text="Add Account">
+              <button
+                className="
+                  btn btn--small@next
+                  
+                  btn--dark-tertiary flush
+                "
+                onClick={[Function]}
+                style={Object {}}>
+                Add Account
+              </button>
+            </SmallButton>
+          </Component>
         </div>
       </div>
     </SectionHeader>


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Apparently, we just needed to validate credit cards when creating a saved payment, and they'd work `¯\_(ツ)_/¯ `

# QA
- I've tested this by adding a card and a bank account both without a transaction.
- I've scheduled gifts with both of these accounts
- I've given one-time gifts with both of these accounts.
- NMI shows them as processing or successful 👍 

# Testing/Documentation
- [x] All significant new logic is covered by tests.
- [x] Changelog has been updated.
