### PR TITLE
Remove auto-liking for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## UNRELEASED
-
-## [5.2.0]
+## [5.2.0] UNRELEASED
 ### Updated
 - Updated the feed card to remove the time stamp.
 - Updated the home feed to no longer have the first card be a hero card. It's now
 a regular card just like everything else.
 - Updated numbers on financial report and added button to detailed pdf
+- Removed auto-like after login
 ### Added
 - Added a "Prompt Modal" to prompt users of necessary information.
 - Push notifications!

--- a/imports/components/@enhancers/likes/toggle.js
+++ b/imports/components/@enhancers/likes/toggle.js
@@ -68,10 +68,18 @@ export const classWrapper = (
       if (Meteor.userId() && this.props.modal && this.props.modal.visible) dispatch(modal.hide());
 
       if (!Meteor.userId()) { // if not logged in, show login modal
+        /*
+          XXX removing the auto-like after login because...
+          1. User clicks login in modal
+          2. redux dispatch toggles the like briefly
+          3. meteor person data gets back and resets the likes in the store
+          4. a few seconds later (why so long??) the likes mutation gets back and re-likes the item
+          XXX until we can fix this, I think it'd be better not to auto-like
+        */
+        // onFinished: this.toggleLike,
         dispatch(modal.render(OnBoard, {
           coverHeader: true,
           modalBackground: "light",
-          onFinished: this.toggleLike,
         }));
       } else { // if logged in, toggle like state in redux, remote with gql query
         const nodeId = this.getNodeId();


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- as described in the code changes, the autolike feature after login is a bit nondeterministic right now, and I think it'd be better to release it without autoliking until fixed. 

# Testing/Documentation
- [x] All significant new logic is covered by tests.
- [x] Changelog has been updated.
