### PR TITLE
fixing the credit card expiration input field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [5.2.3] UNRELEASED
 ### Added
 ### Fixed
+- fixed credit card expiration date input to make it easier to change the date
 ### Updated
 
 ## [5.2.2] 2017.07.11

--- a/imports/components/giving/checkout-views/fieldsets/payment/__tests__/index.js
+++ b/imports/components/giving/checkout-views/fieldsets/payment/__tests__/index.js
@@ -24,7 +24,7 @@ const generateComponent = (additionalProps = {}) => {
     ...defaultProps,
     ...additionalProps,
   };
-  return <Payment { ...newProps } />;
+  return <Payment {...newProps} />;
 };
 
 it("should render with props", () => {
@@ -34,9 +34,11 @@ it("should render with props", () => {
 
 it("savePayment should change save state and call save", () => {
   const mockSave = jest.fn();
-  const wrapper = shallow(generateComponent({
-    save: mockSave,
-  }));
+  const wrapper = shallow(
+    generateComponent({
+      save: mockSave,
+    })
+  );
 
   expect(wrapper.state().save).toBeTruthy();
   expect(mockSave).toHaveBeenCalledTimes(0);
@@ -52,9 +54,11 @@ it("savePayment should change save state and call save", () => {
 
 it("saveName should not call save if no value", () => {
   const mockSave = jest.fn();
-  const wrapper = shallow(generateComponent({
-    save: mockSave,
-  }));
+  const wrapper = shallow(
+    generateComponent({
+      save: mockSave,
+    })
+  );
 
   const result = wrapper.instance().saveName("");
   expect(result).toBeFalsy();
@@ -63,9 +67,11 @@ it("saveName should not call save if no value", () => {
 
 it("saveName should call save if value", () => {
   const mockSave = jest.fn();
-  const wrapper = shallow(generateComponent({
-    save: mockSave,
-  }));
+  const wrapper = shallow(
+    generateComponent({
+      save: mockSave,
+    })
+  );
 
   const result = wrapper.instance().saveName("test");
   expect(result).toBeTruthy();
@@ -200,9 +206,11 @@ it("validate ccv returns false if empty", () => {
 
 it("saveData calls save if valid", () => {
   const mockSave = jest.fn();
-  const wrapper = shallow(generateComponent({
-    save: mockSave,
-  }));
+  const wrapper = shallow(
+    generateComponent({
+      save: mockSave,
+    })
+  );
   const mockTarget = document.createElement("input");
   mockTarget.id = "accountNumber";
 
@@ -210,16 +218,18 @@ it("saveData calls save if valid", () => {
   expect(mockSave).toHaveBeenCalledTimes(1);
   expect(mockSave).toHaveBeenCalledWith({
     payment: {
-      "accountNumber": "test",
-    }
+      accountNumber: "test",
+    },
   });
 });
 
 it("saveData does not call save if invalid", () => {
   const mockSave = jest.fn();
-  const wrapper = shallow(generateComponent({
-    save: mockSave,
-  }));
+  const wrapper = shallow(
+    generateComponent({
+      save: mockSave,
+    })
+  );
   const mockTarget = document.createElement("input");
   mockTarget.id = "accountNumber";
 
@@ -237,32 +247,14 @@ it("formatExp returns 5 characters if greater than 5", () => {
   expect(result).toBe("12/12");
 });
 
-it("formatExp updates 1/ if current last number isn't a /", () => {
-  const wrapper = shallow(generateComponent({
-    data: {
-      payment: {
-        expiration: "1",
-      },
-    },
-  }));
-  const mockTarget = document.createElement("input");
-  mockTarget.id = "expiration";
-
-  const result = wrapper.instance().formatExp("1/", mockTarget);
-  expect(result.length).toBe(3);
-  expect(result).toBe("1//");
-});
-
-// XXX i'm not sure how this is useful.
-// seems like unintended functionality
-it("formatExp prepends `0` and appends `/` when only `/`", () => {
+it("formatExp prepends `0` and appends `/` when only 2-9", () => {
   const wrapper = shallow(generateComponent());
   const mockTarget = document.createElement("input");
   mockTarget.id = "expiration";
 
-  const result = wrapper.instance().formatExp("/", mockTarget);
+  const result = wrapper.instance().formatExp("2", mockTarget);
   expect(result.length).toBe(3);
-  expect(result).toBe("0//");
+  expect(result).toBe("02/");
 });
 
 it("formatExp appends trailing slash when 2 numbers", () => {
@@ -275,14 +267,14 @@ it("formatExp appends trailing slash when 2 numbers", () => {
   expect(result).toBe("12/");
 });
 
-it("formatExp removes trailing slash when 4 numbers", () => {
+it("formatExp carries over month when second value is 3 or higher", () => {
   const wrapper = shallow(generateComponent());
   const mockTarget = document.createElement("input");
   mockTarget.id = "expiration";
 
-  const result = wrapper.instance().formatExp("123/", mockTarget);
-  expect(result.length).toBe(3);
-  expect(result).toBe("123");
+  const result = wrapper.instance().formatExp("13", mockTarget);
+  expect(result.length).toBe(4);
+  expect(result).toBe("01/3");
 });
 
 it("formatExp leaves it alone if fine", () => {
@@ -297,9 +289,11 @@ it("formatExp leaves it alone if fine", () => {
 
 it("toggle changes the payment type to ach if not ach", () => {
   const mockSave = jest.fn();
-  const wrapper = shallow(generateComponent({
-    save: mockSave,
-  }));
+  const wrapper = shallow(
+    generateComponent({
+      save: mockSave,
+    })
+  );
   wrapper.instance().toggle();
   expect(mockSave).toHaveBeenCalledTimes(1);
   expect(mockSave).toHaveBeenCalledWith({
@@ -311,14 +305,16 @@ it("toggle changes the payment type to ach if not ach", () => {
 
 it("toggle changes the payment type to cc if ach", () => {
   const mockSave = jest.fn();
-  const wrapper = shallow(generateComponent({
-    data: {
-      payment: {
-        type: "ach",
+  const wrapper = shallow(
+    generateComponent({
+      data: {
+        payment: {
+          type: "ach",
+        },
       },
-    },
-    save: mockSave,
-  }));
+      save: mockSave,
+    })
+  );
   wrapper.instance().toggle();
   expect(mockSave).toHaveBeenCalledTimes(1);
   expect(mockSave).toHaveBeenCalledWith({

--- a/imports/components/giving/checkout-views/fieldsets/payment/index.js
+++ b/imports/components/giving/checkout-views/fieldsets/payment/index.js
@@ -15,11 +15,11 @@ type IPayment = {
   transactionType: string,
   schedule: Object,
   back: Function,
-  next: Function,
-}
+  next: Function
+};
 
 type IPaymentState = {
-  save: boolean,
+  save: boolean
 };
 
 export default class Payment extends Component {
@@ -28,7 +28,7 @@ export default class Payment extends Component {
 
   state = {
     save: true,
-  }
+  };
 
   savePayment = (): void => {
     this.setState(({ save }) => ({ save: !save }));
@@ -36,15 +36,15 @@ export default class Payment extends Component {
     if (this.state.save) {
       this.props.save({ payment: { name: null } });
     }
-  }
+  };
 
   saveName = (value: string): boolean => {
     if (value.length > 0) {
       this.props.save({ payment: { name: value } });
     }
 
-    return (value.length > 0);
-  }
+    return value.length > 0;
+  };
 
   validate = (value: string, target: HTMLElement): boolean => {
     const { id } = target;
@@ -52,7 +52,7 @@ export default class Payment extends Component {
     if ((id === "cardNumber" || id === "routingNumber") && !value) return true;
 
     let isValid = false;
-    const notEmpty = (inputVal) => (inputVal.length > 0);
+    const notEmpty = (inputVal) => inputVal.length > 0;
     const validationMap = {
       accountNumber: notEmpty,
       routingNumber: notEmpty,
@@ -66,17 +66,17 @@ export default class Payment extends Component {
     isValid = validationMap[id](value);
 
     return isValid;
-  }
+  };
 
   saveData = (value: string, target: HTMLElement) => {
     const { id } = target;
 
     const isValid = this.validate(value, target);
 
-    if (isValid) {
+    if (isValid || (id === "expiration" && value === "")) {
       this.props.save({ payment: { [id]: value } });
     }
-  }
+  };
 
   // XXX move to layout, but changes to input are needed
   formatExp = (s: string, target: HTMLInputElement): string => {
@@ -96,32 +96,31 @@ export default class Payment extends Component {
 
     const copy = str;
     const lastNumber = copy.slice(-1);
-    const currentLastNumber = current.slice(-1);
+    // const currentLastNumber = current.slice(-1);
+    const currentFirstNumber = copy.slice(0, 1);
 
-    // prepend 0 if only character is `/`
-    // XXX i'm not sure how this is useful?
-    if (lastNumber === "/" && str.length === 1) {
+    if (current === `${str}/`) {
+      return save(`${str}`);
+    }
+
+    if (Number(lastNumber) > 2 && currentFirstNumber === "1" && str.length === 2) {
+      return save(`0${currentFirstNumber}/${lastNumber}`);
+    }
+
+    if (lastNumber !== "1" && lastNumber !== "0" && str.length === 1) {
       return save(`0${str}/`);
     }
 
-    // 1/ becomes 1/
-    if (lastNumber === "/" && str.length === 2 && currentLastNumber !== "/") {
+    if (lastNumber !== "/" && str.length === 2) {
       return save(`${str}/`);
     }
 
-    // append `/` if two numbers present
-    // 12 becomes 12/
-    if (str.length === 2 && lastNumber !== "/" && currentLastNumber !== "/") {
-      return save(`${str}/`);
+    if (lastNumber === "/" && currentFirstNumber === "1" && str.length === 2) {
+      return save(`0${str}`);
     }
 
-    // remove trailing `/`
-    if (str.length === 4 && (lastNumber === "/")) {
-      return save(str.slice(0, 3));
-    }
-
-    return save(str);
-  }
+    return save(`${str}`);
+  };
 
   toggle = (): void => {
     let type = "ach";
@@ -130,7 +129,7 @@ export default class Payment extends Component {
     }
 
     this.props.save({ payment: { type } });
-  }
+  };
 
   render() {
     return (
@@ -141,9 +140,7 @@ export default class Payment extends Component {
         savePayment={this.savePayment}
         toggle={this.toggle}
         validate={this.validate}
-
         shouldSaveState={this.state.save}
-
         back={this.props.back}
         header={this.props.header}
         next={this.props.next}

--- a/imports/util/validate/credit-card.js
+++ b/imports/util/validate/credit-card.js
@@ -22,10 +22,19 @@ const creditCard = (value) => {
 };
 
 const creditExpiry = (value) => {
-  const d = moment(value, "MM/YY");
+  let d;
+
+  if (value.length <= 3) {
+    d = value.replace(/\D/g, "");
+    d = moment(value, "MM");
+  } else {
+    d = moment(value, "MM/YY");
+    if (d.isBefore(moment().subtract(1, "month")) || d.isAfter(moment().add(15, "years"))) {
+      return false;
+    }
+  }
+
   if (d == null || !d.isValid()) return false;
-  if (d.isBefore(moment().subtract(1, "month")) ||
-      d.isAfter(moment().add(15, "years"))) return false;
   return true;
 };
 
@@ -34,8 +43,4 @@ const creditCVV = (value) => {
   return regex.test(value);
 };
 
-export {
-  creditCard,
-  creditExpiry,
-  creditCVV,
-};
+export { creditCard, creditExpiry, creditCVV };


### PR DESCRIPTION
input senarios:
- enters `12`, result is `12/`
- enters `13`, result is `01/3`
- enters `4`, result is `04/`

backspace carries over through the `/`