### PR TITLE
added RecordTypeValueId to Person when created in Rock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [5.2.3] UNRELEASED
 ### Added
 ### Fixed
+- Added RecordTypeValueId to Person
 ### Updated
 
 ## [5.2.2] 2017.07.11

--- a/imports/deprecated/methods/accounts/server/signup.js
+++ b/imports/deprecated/methods/accounts/server/signup.js
@@ -67,6 +67,7 @@ Meteor.methods({
       LastName: stripTags(account.lastName),
       IsSystem: false,
       Gender: 0,
+      RecordTypeValueId: 1,
       ConnectionStatusValueId: 67, // Web Prospect
       SystemNote: `Created from NewSpring Apollos on ${__meteor_runtime_config__.ROOT_URL}`,
     };


### PR DESCRIPTION
# Feature / Fixed Issue(s)
- Added RecordTypeValueId to Person when they are created in Rock. Not having this value prevents new users from being checked-in.
