### PR TITLE
Use Trusty, unset TZ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 # - osx
 # osx_image: xcode7.3
 language: node_js
-dist: precise
+dist: trusty
 node_js:
 - '6'
 addons:
@@ -23,7 +23,7 @@ cache:
     - $HOME/.yarn-cache
     - node_modules
 before_install:
-  - echo 'America/New_York' | sudo tee /etc/timezone
+  - unset TZ
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
   - chmod +x $TRAVIS_BUILD_DIR/.travis/run_on_pull_requests
   - chmod +x $TRAVIS_BUILD_DIR/.travis/run_for_coverage


### PR DESCRIPTION
# Feature / Fixed Issue(s)
Fix Travis CI builds on Trusty by unsetting `TZ`.

# Testing/Documentation
- [ ] All significant new logic is covered by tests.
- [ ] Storybook documentation has been added.
- [ ] Changelog has been updated.

# Screenshots
- If applicable, include screenshots of UI/style changes.

# QA Process
All new features and fixes should be tested and signed off on in the [device testing document](https://docs.google.com/spreadsheets/d/1TG0jmltkp61oRA4nYpcoGFTh1lDxa1A8dSnitBKT0lk/edit#gid=1270385294) that corresponds to this PR. **This PR should be tested and PASS on all devices/breakpoints prior to releasing.**

# Reporting Bugs
If you find an issue, a bug, or something that seems weird, thank you! That is extremely helpful. You can report this kind of feedback using our [GitHub Issues page](https://github.com/NewSpring/Holtzman/issues). Here are a few things that are great to include in an issue:

- Reference to this pull request.
- Steps to reproduce the issue
- Explanation of the buggy behavior
- Explanation of the expected behavior
- Screenshots of the app if helpful

Here is a link to a [good example issue.](https://github.com/NewSpring/Apollos/issues/841)
